### PR TITLE
Add notification reply helper

### DIFF
--- a/run.py
+++ b/run.py
@@ -48,7 +48,8 @@ async def _main(username: str, session: str) -> None:
     # ensure_user(username, password)
 
     async with agent.TeamChatSession(user=username, session=session, think=False) as chat:
-        await chat.send_notification("Session started")
+        async for resp in chat.send_notification_stream("Session started"):
+            print("TEAM >>", resp)
         # async for part in chat.chat_stream(
         #     "solve cancer. do not come back until you have a solution.",
         # ):


### PR DESCRIPTION
## Summary
- enable capturing LLM replies to notifications
- print any notification replies in `run.py`
- every generated message is now yielded to clients

## Testing
- `python -m py_compile agent/chat/session.py run.py`


------
https://chatgpt.com/codex/tasks/task_e_685444de11308321bda5abca4ebb2070