### PR TITLE
Add interactive WebSocket client example

### DIFF
--- a/agent/server/__main__.py
+++ b/agent/server/__main__.py
@@ -4,7 +4,6 @@ import asyncio
 import argparse
 
 from . import AgentWebSocketServer
-from ..vm import VMRegistry
 
 
 async def _main(host: str, port: int) -> None:
@@ -30,5 +29,3 @@ if __name__ == "__main__":
         main()
     except KeyboardInterrupt:
         pass
-    finally:
-        VMRegistry.shutdown_all()

--- a/agent/server/websocket.py
+++ b/agent/server/websocket.py
@@ -7,6 +7,8 @@ from urllib.parse import parse_qs, urlparse
 from websockets.exceptions import ConnectionClosed
 from websockets.server import WebSocketServer, WebSocketServerProtocol, serve
 
+from ..vm import VMRegistry
+
 from ..sessions.team import TeamChatSession
 from ..config import Config, DEFAULT_CONFIG
 from ..utils.logging import get_logger
@@ -61,11 +63,12 @@ class AgentWebSocketServer:
         self._log.info("Server listening on %s:%d", self._host, self._port)
 
     async def stop(self) -> None:
-        """Stop the server and close all connections."""
+        """Stop the server, close connections, and cleanup VMs."""
         if self._server is None:
             return
         self._server.close()
         await self._server.wait_closed()
+        VMRegistry.shutdown_all()
 
     async def _handler(self, ws: WebSocketServerProtocol) -> None:
         params = parse_qs(urlparse(ws.path).query)

--- a/run_ws.py
+++ b/run_ws.py
@@ -1,4 +1,81 @@
-from agent.server.__main__ import main
+from __future__ import annotations
+
+"""Interactive WebSocket client for streaming chat messages.
+
+This script connects to an :class:`~agent.server.AgentWebSocketServer` instance
+and keeps the WebSocket connection open indefinitely. User prompts are sent as
+soon as they are entered while LLM responses and VM notifications are streamed
+back immediately. The connection remains open so that notifications can be
+delivered even when the user is idle.
+"""
+
+import argparse
+import asyncio
+from contextlib import suppress
+
+import websockets
+
+from agent.utils.logging import get_logger
+
+_LOG = get_logger(__name__)
+
+
+async def _receiver(ws: websockets.WebSocketClientProtocol) -> None:
+    """Print all messages received from the server."""
+
+    try:
+        async for msg in ws:
+            print(msg, end="", flush=True)
+    except websockets.ConnectionClosed:
+        _LOG.info("Connection closed by server")
+
+
+async def chat(uri: str, message: str) -> None:
+    """Connect to ``uri`` and interactively exchange chat messages."""
+
+    async with websockets.connect(uri) as ws:
+        _LOG.info("Connected to %s", uri)
+        if message:
+            await ws.send(message)
+
+        recv_task = asyncio.create_task(_receiver(ws))
+        try:
+            loop = asyncio.get_running_loop()
+            while True:
+                prompt = await loop.run_in_executor(None, input, "> ")
+                await ws.send(prompt)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            recv_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await recv_task
+
+
+def _build_uri(host: str, port: int, user: str, session: str) -> str:
+    return f"ws://{host}:{port}/?user={user}&session={session}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Interactive WebSocket client")
+    parser.add_argument("--host", default="localhost", help="Server host")
+    parser.add_argument("--port", type=int, default=8765, help="Server port")
+    parser.add_argument("--user", default="demo", help="Username")
+    parser.add_argument("--session", default="ws", help="Session identifier")
+    parser.add_argument(
+        "--message",
+        default="Hello from the client!",
+        help="Optional message to send on connect",
+    )
+    args = parser.parse_args()
+
+    uri = _build_uri(args.host, args.port, args.user, args.session)
+    asyncio.run(chat(uri, args.message))
+
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass
+


### PR DESCRIPTION
## Summary
- replace server script `run_ws.py` with an interactive WebSocket client
- client keeps the connection open and streams messages both ways
- server shutdown still performs VM cleanup

## Testing
- `python -m py_compile run_ws.py agent/server/websocket.py agent/server/__main__.py`
- `python run_ws.py --help` *(fails: No module named 'ollama')*

------
https://chatgpt.com/codex/tasks/task_e_6854529abd6c83219b183d04e7bd99a5