### PR TITLE
Add think option to websocket API

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Launch a persistent WebSocket service to stream responses and VM notifications:
 python -m agent.server --host 0.0.0.0 --port 8765
 ```
 
-Clients should connect via the WebSocket protocol and can specify the user and
-session identifiers using query parameters:
-`ws://HOST:PORT/?user=<name>&session=<id>`.
+Clients should connect via the WebSocket protocol and can specify the user,
+session and optional think parameters using query parameters:
+`ws://HOST:PORT/?user=<name>&session=<id>&think=<true|false>`.
 
 Here is a minimal client that keeps the connection open, sends user input and
 prints all output from the agent including asynchronous notifications:
@@ -88,7 +88,7 @@ import websockets
 
 
 async def chat():
-    uri = "ws://localhost:8765/?user=demo&session=ws"
+    uri = "ws://localhost:8765/?user=demo&session=ws&think=false"
     async with websockets.connect(uri) as ws:
         print("Connected. Press Ctrl+C to exit.")
 

--- a/agent/server/websocket.py
+++ b/agent/server/websocket.py
@@ -74,9 +74,17 @@ class AgentWebSocketServer:
         params = parse_qs(urlparse(ws.path).query)
         user = params.get("user", ["default"])[0]
         session = params.get("session", ["default"])[0]
+        think_param = params.get("think", ["true"])[0]
+        think = think_param.lower() not in ("false", "0", "no")
 
         out_q: asyncio.Queue[str] = asyncio.Queue()
-        chat = StreamingTeamChatSession(user=user, session=session, output_queue=out_q, config=self._config)
+        chat = StreamingTeamChatSession(
+            user=user,
+            session=session,
+            think=think,
+            output_queue=out_q,
+            config=self._config,
+        )
         async with chat:
             sender = asyncio.create_task(self._sender(ws, out_q))
             try:

--- a/run_ws.py
+++ b/run_ws.py
@@ -52,8 +52,9 @@ async def chat(uri: str, message: str) -> None:
                 await recv_task
 
 
-def _build_uri(host: str, port: int, user: str, session: str) -> str:
-    return f"ws://{host}:{port}/?user={user}&session={session}"
+def _build_uri(host: str, port: int, user: str, session: str, think: bool) -> str:
+    think_val = "true" if think else "false"
+    return f"ws://{host}:{port}/?user={user}&session={session}&think={think_val}"
 
 
 def main() -> None:
@@ -62,6 +63,20 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=8765, help="Server port")
     parser.add_argument("--user", default="demo", help="Username")
     parser.add_argument("--session", default="ws", help="Session identifier")
+    think_group = parser.add_mutually_exclusive_group()
+    think_group.add_argument(
+        "--think",
+        dest="think",
+        action="store_true",
+        help="Enable model thinking (default)",
+    )
+    think_group.add_argument(
+        "--no-think",
+        dest="think",
+        action="store_false",
+        help="Disable model thinking",
+    )
+    parser.set_defaults(think=True)
     parser.add_argument(
         "--message",
         default="Hello from the client!",
@@ -69,7 +84,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    uri = _build_uri(args.host, args.port, args.user, args.session)
+    uri = _build_uri(args.host, args.port, args.user, args.session, args.think)
     asyncio.run(chat(uri, args.message))
 
 


### PR DESCRIPTION
## Summary
- make `think` configurable via websocket query parameters
- support `--think`/`--no-think` flags in the demo client
- document websocket `think` parameter in README

## Testing
- `python -m py_compile agent/server/websocket.py run_ws.py`

------
https://chatgpt.com/codex/tasks/task_e_685457ca73d8832182f2d93681f274d8