### PR TITLE
Use websocket API in Discord bot

### DIFF
--- a/bot/ws_api.py
+++ b/bot/ws_api.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import AsyncIterator
+
+import websockets
+
+from agent.utils.logging import get_logger
+
+
+class WSApiClient:
+    """Simple client for :mod:`agent.server` WebSocket API."""
+
+    def __init__(self, host: str = "localhost", port: int = 8765) -> None:
+        self._host = host
+        self._port = port
+        self._log = get_logger(__name__)
+
+    def _build_uri(self, user: str, session: str, think: bool) -> str:
+        think_val = "true" if think else "false"
+        return f"ws://{self._host}:{self._port}/?user={user}&session={session}&think={think_val}"
+
+    async def team_chat_stream(
+        self,
+        prompt: str,
+        *,
+        user: str,
+        session: str,
+        think: bool = True,
+        extra: dict[str, str] | None = None,
+        timeout: float = 1.0,
+    ) -> AsyncIterator[str]:
+        """Yield chat responses for ``prompt`` sent to the server."""
+
+        uri = self._build_uri(user, session, think)
+        payload: dict[str, object] = {"command": "team_chat", "args": {"prompt": prompt}}
+        if extra:
+            payload["args"].update(extra)
+
+        async with websockets.connect(uri) as ws:
+            await ws.send(json.dumps(payload))
+            while True:
+                try:
+                    msg = await asyncio.wait_for(ws.recv(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    break
+                else:
+                    yield msg
+
+    async def request(
+        self,
+        command: str,
+        *,
+        user: str,
+        session: str,
+        think: bool = True,
+        timeout: float = 10.0,
+        **params: object,
+    ) -> object:
+        """Send a command and return the parsed JSON response."""
+
+        uri = self._build_uri(user, session, think)
+        payload = {"command": command, "args": params}
+
+        async with websockets.connect(uri) as ws:
+            await ws.send(json.dumps(payload))
+            try:
+                raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
+            except asyncio.TimeoutError as exc:
+                raise RuntimeError("Server did not respond in time") from exc
+
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            self._log.error("Invalid JSON response: %s", raw)
+            raise RuntimeError("Invalid server response")
+


### PR DESCRIPTION
## Summary
- add a `WSApiClient` to interact with the WebSocket server
- refactor Discord bot to send chat and VM commands through the WS API

## Testing
- `python -m py_compile bot/ws_api.py bot/discord_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68546af69c9c8321b5e837db4f07435a