### PR TITLE
Fix Discord bot message timeout

### DIFF
--- a/bot/discord_bot.py
+++ b/bot/discord_bot.py
@@ -69,6 +69,7 @@ class DiscordTeamBot(commands.Bot):
                     user=user,
                     session=session_id,
                     think=False,
+                    timeout=30.0,
                     extra={
                         "user_name": str(message.author.name),
                         "channel_name": str(message.channel.name),
@@ -86,6 +87,7 @@ class DiscordTeamBot(commands.Bot):
                     user=user,
                     session=session_id,
                     think=False,
+                    timeout=30.0,
                 ):
                     await message.reply(part, mention_author=False)
             except Exception as exc:  # pragma: no cover - runtime errors

--- a/bot/ws_api.py
+++ b/bot/ws_api.py
@@ -29,9 +29,17 @@ class WSApiClient:
         session: str,
         think: bool = True,
         extra: dict[str, str] | None = None,
-        timeout: float = 1.0,
+        timeout: float = 30.0,
     ) -> AsyncIterator[str]:
-        """Yield chat responses for ``prompt`` sent to the server."""
+        """Yield chat responses for ``prompt`` sent to the server.
+
+        Parameters
+        ----------
+        timeout:
+            Seconds to wait for the next message before concluding the
+            stream. Increase this if the model takes a long time to
+            produce a reply.
+        """
 
         uri = self._build_uri(user, session, think)
         payload: dict[str, object] = {"command": "team_chat", "args": {"prompt": prompt}}


### PR DESCRIPTION
## Summary
- extend websocket timeout in `WSApiClient`
- pass a higher timeout when streaming responses in the Discord bot

## Testing
- `pip install -q -r requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68546eda4f0c832186ead6207a663c3b