### PR TITLE
Fix sequential tool call handling

### DIFF
--- a/agent/chat/session.py
+++ b/agent/chat/session.py
@@ -531,11 +531,12 @@ class ChatSession:
 
         max_depth = self._config.max_tool_call_depth
         while depth < max_depth and response.message.tool_calls:
-            # Handle a single tool call then obtain a fresh response. This
-            # gives the model a chance to react to each tool's output before
-            # deciding on the next action.
-            call = response.message.tool_calls[0]
-            async for nxt in self._process_tool_call(call, messages, conversation):
+            # Handle each tool call sequentially so the model can react to
+            # every tool's output before moving on to the next one.
+            call = response.message.tool_calls.pop(0)
+            async for nxt in self._process_tool_call(
+                call, messages, conversation
+            ):
                 response = nxt
                 yield nxt
             depth += 1


### PR DESCRIPTION
## Summary
- handle multiple tool calls in one response by processing them sequentially

## Testing
- `pip install -q -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_6855310f8c108321a56cfa0466679b53