### PR TITLE
Enable persistent VM shell and remove default timeout

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -15,6 +15,7 @@ from .simple import (
 from .tools import (
     execute_terminal,
     execute_terminal_async,
+    execute_terminal_stream,
     execute_with_secret,
     execute_with_secret_async,
     set_vm,
@@ -31,6 +32,7 @@ __all__ = [
     "TeamChatSession",
     "execute_terminal",
     "execute_terminal_async",
+    "execute_terminal_stream",
     "set_team",
     "set_vm",
     "execute_with_secret",

--- a/agent/chat/session.py
+++ b/agent/chat/session.py
@@ -23,7 +23,7 @@ from ..utils.logging import get_logger
 from .schema import Msg
 from contextlib import suppress
 
-from ..tools import execute_terminal, set_vm, create_memory_tool
+from ..tools import execute_terminal_async, set_vm, create_memory_tool
 from ..utils.memory import (
     get_memory,
     edit_memory as _edit_memory,
@@ -77,7 +77,8 @@ class ChatSession:
         memory_tool = create_memory_tool(
             self._user.username, self._refresh_system_prompt
         )
-        self._tools = (tools or [execute_terminal]) + [memory_tool]
+        default_tool = execute_terminal_async
+        self._tools = (tools or [default_tool]) + [memory_tool]
         self._tool_funcs = {func.__name__: func for func in self._tools}
         self._think = think
         self._current_tool_name: str | None = None

--- a/agent/config/__init__.py
+++ b/agent/config/__init__.py
@@ -19,7 +19,8 @@ VM_STATE_DIR: Final[str] = os.getenv(
 )
 VM_DOCKER_HOST: Final[str | None] = os.getenv("VM_DOCKER_HOST")
 DB_PATH: Final[str] = os.getenv("DB_PATH", str(Path.cwd() / "chat.db"))
-HARD_TIMEOUT: Final[int] = int(os.getenv("HARD_TIMEOUT", "5"))
+_timeout_env = os.getenv("HARD_TIMEOUT")
+HARD_TIMEOUT: Final[int | None] = int(_timeout_env) if _timeout_env else None
 LOG_LEVEL: Final[str] = os.getenv("LOG_LEVEL", "INFO").upper()
 SECRET_KEY: Final[str] = os.getenv("SECRET_KEY", "CHANGE_ME")
 ACCESS_TOKEN_EXPIRE_MINUTES: Final[int] = int(
@@ -163,7 +164,7 @@ class Config:
     vm_state_dir: str = VM_STATE_DIR
     vm_docker_host: str | None = VM_DOCKER_HOST
     db_path: str = DB_PATH
-    hard_timeout: int = HARD_TIMEOUT
+    hard_timeout: int | None = HARD_TIMEOUT
     log_level: str = LOG_LEVEL
     secret_key: str = SECRET_KEY
     access_token_expire_minutes: int = ACCESS_TOKEN_EXPIRE_MINUTES

--- a/agent/vm/shell.py
+++ b/agent/vm/shell.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from contextlib import suppress
+from typing import AsyncIterator
+
+from ..utils.logging import get_logger
+
+
+class PersistentShell:
+    """Maintain a persistent bash session inside a running container."""
+
+    def __init__(self, container_name: str, env: dict[str, str] | None = None) -> None:
+        self._container = container_name
+        self._env = env
+        self._proc: asyncio.subprocess.Process | None = None
+        self._queue: asyncio.Queue[str] = asyncio.Queue()
+        self._reader: asyncio.Task | None = None
+        self._log = get_logger(__name__)
+
+    async def start(self) -> None:
+        if self._proc:
+            return
+        self._proc = await asyncio.create_subprocess_exec(
+            "docker",
+            "exec",
+            "-i",
+            self._container,
+            "bash",
+            "-i",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            env=self._env,
+        )
+        self._reader = asyncio.create_task(self._read_loop())
+
+    async def _read_loop(self) -> None:
+        assert self._proc and self._proc.stdout
+        while True:
+            line = await self._proc.stdout.readline()
+            if not line:
+                break
+            await self._queue.put(line.decode())
+
+    async def stop(self) -> None:
+        if self._reader and not self._reader.done():
+            self._reader.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._reader
+        if self._proc and self._proc.returncode is None:
+            self._proc.terminate()
+            with suppress(Exception):
+                await self._proc.wait()
+        self._proc = None
+        self._reader = None
+
+    async def execute(self, command: str) -> str:
+        """Run ``command`` in the persistent shell and return the output."""
+        result: list[str] = []
+        async for part in self.execute_stream(command):
+            result.append(part)
+        return "".join(result)
+
+    async def execute_stream(self, command: str) -> AsyncIterator[str]:
+        """Yield command output incrementally as it is produced."""
+        await self.start()
+        assert self._proc and self._proc.stdin
+        sentinel = f"__CMD_DONE_{uuid.uuid4().hex}__"
+        self._proc.stdin.write(f"{command}\necho {sentinel}\n".encode())
+        await self._proc.stdin.drain()
+        while True:
+            line = await self._queue.get()
+            if sentinel in line:
+                break
+            yield line


### PR DESCRIPTION
## Summary
- allow unlimited `hard_timeout` by setting env var to empty
- support persistent shell sessions inside `LinuxVM`
- stream terminal commands via `execute_terminal_stream`
- default chat tool uses async execution for shared shell state

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_685534b2cfdc83218c4239e663feaf9b