### PR TITLE
Fix VM upload path and config handling

### DIFF
--- a/agent/chat/session.py
+++ b/agent/chat/session.py
@@ -141,7 +141,7 @@ class ChatSession:
         self._think = value
 
     async def __aenter__(self) -> "ChatSession":
-        self._vm = VMRegistry.acquire(self._user.username)
+        self._vm = VMRegistry.acquire(self._user.username, config=self._config)
         set_vm(self._vm)
         self._notification_task = asyncio.create_task(self._monitor_notifications())
         return self

--- a/agent/server/endpoints.py
+++ b/agent/server/endpoints.py
@@ -105,7 +105,7 @@ async def _list_dir_handler(
     chat: TeamChatSession | None,
 ) -> AsyncIterator[str]:
     path = str(params["path"])
-    listing = await list_dir(path, user=user)
+    listing = await list_dir(path, user=user, config=config)
     yield json.dumps({"result": list(listing)})
 
 
@@ -118,7 +118,7 @@ async def _read_file_handler(
     chat: TeamChatSession | None,
 ) -> AsyncIterator[str]:
     path = str(params["path"])
-    content = await read_file(path, user=user)
+    content = await read_file(path, user=user, config=config)
     yield json.dumps({"result": content})
 
 
@@ -132,7 +132,7 @@ async def _write_file_handler(
 ) -> AsyncIterator[str]:
     path = str(params["path"])
     content = str(params.get("content", ""))
-    result = await write_file(path, content, user=user)
+    result = await write_file(path, content, user=user, config=config)
     yield json.dumps({"result": result})
 
 
@@ -145,7 +145,7 @@ async def _delete_path_handler(
     chat: TeamChatSession | None,
 ) -> AsyncIterator[str]:
     path = str(params["path"])
-    result = await delete_path(path, user=user)
+    result = await delete_path(path, user=user, config=config)
     yield json.dumps({"result": result})
 
 
@@ -161,7 +161,7 @@ async def _vm_execute_handler(
     timeout = params.get("timeout")
     if timeout is not None:
         timeout = int(timeout)
-    result = await vm_execute(cmd, user=user, timeout=timeout)
+    result = await vm_execute(cmd, user=user, timeout=timeout, config=config)
     yield json.dumps({"result": result})
 
 
@@ -174,7 +174,7 @@ async def _vm_execute_stream_handler(
     chat: TeamChatSession | None,
 ) -> AsyncIterator[str]:
     cmd = str(params["command"])
-    async for part in vm_execute_stream(cmd, user=user):
+    async for part in vm_execute_stream(cmd, user=user, config=config):
         yield part
 
 
@@ -187,7 +187,7 @@ async def _send_notification_handler(
     chat: TeamChatSession | None,
 ) -> AsyncIterator[str]:
     message = str(params["message"])
-    send_notification(message, user=user)
+    send_notification(message, user=user, config=config)
     yield json.dumps({"result": "ok"})
 
 

--- a/agent/vm/__init__.py
+++ b/agent/vm/__init__.py
@@ -45,9 +45,9 @@ class LinuxVM:
         self._image = config.vm_image
         self._name = f"chat-vm-{_sanitize(username)}"
         self._running = False
-        self._host_dir = Path(config.upload_dir) / username
+        self._host_dir = (Path(config.upload_dir) / username).resolve()
         self._host_dir.mkdir(parents=True, exist_ok=True)
-        self._state_dir = Path(config.vm_state_dir) / _sanitize(username)
+        self._state_dir = (Path(config.vm_state_dir) / _sanitize(username)).resolve()
         self._state_dir.mkdir(parents=True, exist_ok=True)
         self._notifications_dir = self._state_dir / "notifications"
         self._notifications_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- propagate custom Config when acquiring VMs
- allow file helpers to accept Config so uploads match VM mount paths
- use Config in server endpoints for file operations
- resolve VM host paths for reliability

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855f58a11b88321a02b88ba69e993c5