### PR TITLE
Refactor API and websockets

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,6 +1,6 @@
 from .chat import ChatSession
 from .sessions.team import TeamChatSession, set_team
-from .simple import (
+from .api import (
     team_chat,
     upload_document,
     upload_data,

--- a/agent/chat/session.py
+++ b/agent/chat/session.py
@@ -24,14 +24,14 @@ from ..utils.logging import get_logger
 from .schema import Msg
 from contextlib import suppress
 
-from ..tools import execute_terminal_async, set_vm, create_memory_tool
+from ..tools import execute_terminal_async, set_vm, create_memory_tool, _VM
 from ..utils.memory import (
     get_memory,
     edit_memory as _edit_memory,
     edit_protected_memory as _edit_protected_memory,
 )
 from ..vm import VMRegistry
-from ..simple import _copy_to_vm_and_verify
+from ..api import _copy_to_vm_and_verify
 
 from .state import SessionState, get_state
 from .messages import (
@@ -149,7 +149,8 @@ class ChatSession:
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
-        set_vm(None)
+        if _VM is self._vm:
+            set_vm(None)
         if self._vm:
             VMRegistry.release(self._user.username)
         if self._notification_task and not self._notification_task.done():

--- a/agent/server/endpoints.py
+++ b/agent/server/endpoints.py
@@ -11,7 +11,7 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Iterable
 import json
 import base64
 
-from ..simple import (
+from ..api import (
     team_chat,
     upload_document,
     upload_data,


### PR DESCRIPTION
## Summary
- delete `simple.py` and move API helpers to new `api.py`
- fix VM reset issue in `ChatSession.__aexit__`
- rewrite websocket server for persistent agent and VM connections
- update imports to use new API module

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m agent.server.__main__ --host 127.0.0.1 --port 9999` *(fails: ModuleNotFoundError: No module named 'ollama')*

------
https://chatgpt.com/codex/tasks/task_e_6856df02782c83219958cbb90232d013