### PR TITLE
Fix API quoting bug and improve Discord bot WS handling

### DIFF
--- a/agent/api.py
+++ b/agent/api.py
@@ -206,7 +206,7 @@ async def write_file(
     encoded = base64.b64encode(content.encode()).decode()
     cmd = (
         "python -c 'import base64,os; "
-        f'open({json.dumps(path)}, "wb").write(base64.b64decode({json.dumps(encoded)}))'"
+        f"open({json.dumps(path)}, \"wb\").write(base64.b64decode({json.dumps(encoded)}))'"
     )
     await vm_execute(cmd, user=user, config=config)
     return "Saved"


### PR DESCRIPTION
## Summary
- repair quoting in `agent/api.py` that caused a SyntaxError
- batch WebSocket messages in Discord bot so streaming output isn't spammy

## Testing
- `python -m py_compile agent/api.py bot/discord_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6856e0e4dc808321bd47cdf282c015e5