### PR TITLE
Fix mini agent streaming and Discord file upload

### DIFF
--- a/agent/server/websocket.py
+++ b/agent/server/websocket.py
@@ -116,6 +116,8 @@ class AgentWebSocketServer:
     async def _send_notifications(self, chat: TeamChatSession, out_q: asyncio.Queue[str]) -> None:
         for part in await chat.poll_notifications():
             await out_q.put(part)
+        for part in await chat.poll_agent_messages():
+            await out_q.put(part)
 
 
 __all__ = ["AgentWebSocketServer"]

--- a/bot/discord_bot.py
+++ b/bot/discord_bot.py
@@ -345,12 +345,50 @@ class DiscordTeamBot(commands.Bot):
             async for msg in conn:
                 file_payload = self._parse_returned_file(msg)
                 if file_payload:
+                    if buffer:
+                        text = "".join(buffer).strip()
+                        if text:
+                            await channel.send(text)
+                        buffer.clear()
+                        last_send = asyncio.get_running_loop().time()
+
                     name, data = file_payload
                     await channel.send(
                         content=f"Returned file: {name}",
                         file=discord.File(BytesIO(data), filename=name),
                     )
                     continue
+
+                remote_path = self._extract_result_path(msg)
+                if remote_path and not Path(remote_path).is_file():
+                    try:
+                        dl_path = await self._client.download_file(
+                            remote_path,
+                            user=conn._user,
+                            session=conn._session,
+                            think=False,
+                        )
+                        f_path = Path(dl_path)
+                        data = f_path.read_bytes()
+                        try:
+                            f_path.unlink()
+                        except Exception:
+                            pass
+
+                        if buffer:
+                            text = "".join(buffer).strip()
+                            if text:
+                                await channel.send(text)
+                            buffer.clear()
+                            last_send = asyncio.get_running_loop().time()
+
+                        await channel.send(
+                            content=f"Returned file: {f_path.name}",
+                            file=discord.File(BytesIO(data), filename=f_path.name),
+                        )
+                        continue
+                    except Exception as exc:  # pragma: no cover - runtime errors
+                        self._log.error("Failed to download %s: %s", remote_path, exc)
 
                 buffer.append(msg)
                 now = asyncio.get_running_loop().time()
@@ -401,6 +439,17 @@ class DiscordTeamBot(commands.Bot):
                 except Exception as exc:  # pragma: no cover - runtime errors
                     self._log.warning("Failed to delete returned file %s: %s", path, exc)
                 return path.name, data
+        return None
+
+    def _extract_result_path(self, msg: str) -> str | None:
+        """Return ``result`` path from ``msg`` if present."""
+
+        try:
+            payload = json.loads(msg)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(payload, dict) and "result" in payload:
+            return str(payload["result"])
         return None
 
     async def _get_connection(


### PR DESCRIPTION
## Summary
- deliver queued mini agent output via poller
- send mini agent updates over websocket
- ensure returned files are uploaded by the Discord bot

## Testing
- `python -m py_compile agent/sessions/team.py agent/server/websocket.py bot/discord_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6856e61bac548321b07c6244d98065c5