### PR TITLE
Implement immediate return file watcher

### DIFF
--- a/agent/vm/__init__.py
+++ b/agent/vm/__init__.py
@@ -73,6 +73,11 @@ class LinuxVM:
     def return_dir(self) -> Path:
         return self._return_dir
 
+    @property
+    def return_queue_dir(self) -> Path:
+        """Directory backing the VM's ``/return`` queue."""
+        return self._return_queue_dir
+
     def start(self) -> None:
         """Start the VM if it is not already running."""
         if self._running:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ python-multipart
 passlib[bcrypt]
 python-jose[cryptography]
 websockets
+watchfiles


### PR DESCRIPTION
## Summary
- expose LinuxVM.return_queue_dir for watchers
- watch `/return` folder using `watchfiles` and send files instantly
- manage watcher lifecycle in chat session
- add `watchfiles` dependency

## Testing
- `python -m py_compile agent/vm/__init__.py agent/chat/session.py bot/discord_bot.py`
- `pip install watchfiles`

------
https://chatgpt.com/codex/tasks/task_e_6856e807ae8083219e49aedf2f2499e3