### PR TITLE
Fix Discord bot file return handling

### DIFF
--- a/agent/server/websocket.py
+++ b/agent/server/websocket.py
@@ -114,7 +114,7 @@ class AgentWebSocketServer:
             pass
 
     async def _send_notifications(self, chat: TeamChatSession, out_q: asyncio.Queue[str]) -> None:
-        for part in await chat.poll_notifications():
+        for part in await chat.poll_notifications(for_user=True):
             await out_q.put(part)
         for part in await chat.poll_agent_messages():
             await out_q.put(part)


### PR DESCRIPTION
## Summary
- preserve returned files for Discord bot until user receives them
- handle VM notifications for Discord clients in websocket server

## Testing
- `flake8`
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_6856e9f95e9483218b292edb5b5210a5