### PR TITLE
Support interactive terminal input via WS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ are transcribed locally and the transcript is uploaded alongside the original
 file. No notification is sent to the LLM for these uploads. Use `!exec <command>` to
 run shell commands manually. Administrators can stop the bot with `!shutdown`.
 
+Interactive prompts from the VM appear as regular messages. Simply reply in the
+channel to forward your response to the shell. If the VM requests input again,
+send another message and it will be forwarded automatically.
+
 ### WebSocket Server
 
 Launch a persistent WebSocket service to stream responses and VM notifications:
@@ -123,6 +127,10 @@ include a ``command`` field and optional ``args`` mapping:
 Responses for non-streaming commands are JSON encoded. Streaming commands such
 as ``team_chat`` send text fragments incrementally.
 
+Interactive commands in the VM may request additional input. When a prompt is
+detected, the server sends a JSON message of the form ``{"stdin_request":
+"<text>"}`` so clients can respond via the ``vm_input`` command.
+
 
 
 ## API Overview
@@ -134,6 +142,8 @@ The :mod:`agent` package exposes a simple async API:
 - `agent.upload_document(path, user, session)` – place a local file in the VM
 - `agent.upload_data(data, filename, user, session)` – upload raw bytes
 - `agent.vm_execute(command, user)` – run a command directly
+- `agent.vm_execute_stream(command, user)` – stream output from a command
+- `agent.vm_send_input(data, user)` – send additional input to the VM shell
 
 Utility helpers exist for listing, reading and writing files as well as editing persistent memory.
 

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -11,6 +11,7 @@ from .api import (
     download_file,
     vm_execute,
     vm_execute_stream,
+    vm_send_input,
     send_notification,
 )
 from .tools import (
@@ -50,6 +51,7 @@ __all__ = [
     "download_file",
     "vm_execute",
     "vm_execute_stream",
+    "vm_send_input",
     "send_notification",
     "transcribe_audio",
     "get_memory",

--- a/agent/server/endpoints.py
+++ b/agent/server/endpoints.py
@@ -22,6 +22,7 @@ from ..api import (
     download_file,
     vm_execute,
     vm_execute_stream,
+    vm_send_input,
     send_notification,
 )
 from ..config import Config
@@ -179,6 +180,19 @@ async def _vm_execute_stream_handler(
         yield part
 
 
+async def _vm_input_handler(
+    params: dict[str, Any],
+    user: str,
+    session: str,
+    think: bool,
+    config: Config,
+    chat: TeamChatSession | None,
+) -> AsyncIterator[str]:
+    data = params.get("data", "")
+    await vm_send_input(str(data), user=user, config=config)
+    yield json.dumps({"result": "ok"})
+
+
 async def _send_notification_handler(
     params: dict[str, Any],
     user: str,
@@ -203,6 +217,7 @@ _HANDLERS: dict[str, Callable[..., AsyncIterator[str]]] = {
     "download_file": _download_file_handler,
     "vm_execute": _vm_execute_handler,
     "vm_execute_stream": _vm_execute_stream_handler,
+    "vm_input": _vm_input_handler,
     "send_notification": _send_notification_handler,
 }
 

--- a/agent/vm/__init__.py
+++ b/agent/vm/__init__.py
@@ -158,6 +158,12 @@ class LinuxVM:
         async for part in shell.execute_stream(command):
             yield part
 
+    async def shell_send_input(self, data: str | bytes) -> None:
+        """Forward ``data`` to the persistent shell's stdin."""
+
+        shell = self._ensure_shell()
+        await shell.send_input(data)
+
     def execute(
         self,
         command: str,

--- a/bot/ws_api.py
+++ b/bot/ws_api.py
@@ -134,6 +134,24 @@ class WSApiClient:
         )
         return str(resp.get("result", ""))
 
+    async def vm_send_input(
+        self,
+        data: str,
+        *,
+        user: str,
+        session: str,
+        think: bool = False,
+    ) -> None:
+        """Send additional input to the user's VM shell."""
+
+        await self.request(
+            "vm_input",
+            user=user,
+            session=session,
+            think=think,
+            data=data,
+        )
+
     async def list_dir(
         self,
         path: str,
@@ -270,6 +288,14 @@ class WSConnection:
         self._think = think
         self._ws: websockets.WebSocketClientProtocol | None = None
 
+    @property
+    def user(self) -> str:
+        return self._user
+
+    @property
+    def session(self) -> str:
+        return self._session
+
     async def connect(self) -> None:
         uri = self._client._build_uri(self._user, self._session, self._think)
         self._ws = await websockets.connect(uri)
@@ -289,3 +315,8 @@ class WSConnection:
             raise RuntimeError("Connection not established")
         async for msg in self._ws:
             yield msg
+
+    async def send_input(self, data: str) -> None:
+        """Send ``data`` to the connected VM shell."""
+
+        await self.send("vm_input", data=data)


### PR DESCRIPTION
## Summary
- expose `vm_send_input` API function for VM stdin
- implement new `vm_input` WebSocket command
- add `send_input` method for WebSocket clients
- extend persistent shell to accept additional input
- document new API functions
- detect interactive shell prompts and forward them over WebSocket
- **add Discord bot support for streaming input requests**

## Testing
- `pip install --quiet colorama`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857126bb85083219be8e41e5608c294