### PR TITLE
Improve interactive CLI handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,9 @@ Responses for non-streaming commands are JSON encoded. Streaming commands such
 as ``team_chat`` send text fragments incrementally.
 
 Interactive commands in the VM may request additional input. When a prompt is
-detected, the server sends a JSON message of the form ``{"stdin_request":
-"<text>"}`` so clients can respond via the ``vm_input`` command.
+detected—typically a line ending with ``?`` or ``:``—the server sends a JSON
+message of the form ``{"stdin_request": "<text>"}`` so clients can respond via
+the ``vm_input`` command.
 
 
 

--- a/agent/vm/shell.py
+++ b/agent/vm/shell.py
@@ -86,6 +86,10 @@ class PersistentShell:
             return True
         if s.endswith(":") and "password" in s:
             return True
+        if s.endswith(":") and "://" not in s:
+            return True
+        if s.endswith(">"):
+            return True
         return False
 
     async def execute_stream(self, command: str) -> AsyncIterator[str]:

--- a/bot/discord_bot.py
+++ b/bot/discord_bot.py
@@ -381,7 +381,8 @@ class DiscordTeamBot(commands.Bot):
                             await channel.send(text)
                         buffer.clear()
                         last_send = asyncio.get_running_loop().time()
-                    await channel.send(prompt)
+                    formatted = f"**VM input requested:** {prompt}"
+                    await channel.send(formatted)
                     self._awaiting_input.add(key)
                     continue
 


### PR DESCRIPTION
## Summary
- detect CLI prompts ending with `:` or `>` to support tools like `khal configure`
- send formatted "VM input requested" messages in Discord
- document how input prompts are detected

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6857297e1bdc832188702f9fd1bbbe03