### PR TITLE
Change VM image to python slim

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Environment variables control most behaviour:
 | `UPLOAD_DIR` | Host directory for uploaded files |
 | `RETURN_DIR` | Host directory for returned files |
 | `DB_PATH` | SQLite database path |
-| `VM_IMAGE` | Docker image used for the VM |
+| `VM_IMAGE` | Docker image used for the VM (`python:3.11-slim` by default) |
 | `VM_CONTAINER_TEMPLATE` | Container name pattern (`chat-vm-{user}`) |
 | `VM_STATE_DIR` | Directory for persistent VM state |
 | `VM_DOCKER_HOST` | Docker host socket (optional) |

--- a/agent/config/__init__.py
+++ b/agent/config/__init__.py
@@ -12,7 +12,7 @@ OLLAMA_HOST: Final[str] = os.getenv("OLLAMA_HOST", "http://localhost:11434")
 MAX_TOOL_CALL_DEPTH: Final[int] = 15
 NUM_CTX: Final[int] = int(os.getenv("OLLAMA_NUM_CTX", "32768"))
 UPLOAD_DIR: Final[str] = os.getenv("UPLOAD_DIR", str(Path.cwd() / "uploads"))
-VM_IMAGE: Final[str] = os.getenv("VM_IMAGE", "archlinux:latest")
+VM_IMAGE: Final[str] = os.getenv("VM_IMAGE", "python:3.11-slim")
 PERSIST_VMS: Final[bool] = os.getenv("PERSIST_VMS", "1") == "1"
 VM_STATE_DIR: Final[str] = os.getenv(
     "VM_STATE_DIR", str(Path.cwd() / "vm_state")

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -48,7 +48,8 @@ def set_vm(vm: LinuxVM | None) -> None:
 
 def execute_terminal(command: str, *, stdin_data: str | bytes | None = None) -> str:
     """
-    Execute a shell command in an **unrestricted** Arch Linux terminal.
+    Execute a shell command in an **unrestricted** terminal running inside
+    a Debian-based Python environment (`python:3.11-slim`).
     Use this tool to inspect uploaded documents under ``/data``, return
     files to the user by moving files under ``/return``,
     and run other commands.
@@ -79,7 +80,8 @@ def execute_terminal(command: str, *, stdin_data: str | bytes | None = None) -> 
 
 async def execute_terminal_async(command: str, *, stdin_data: str | bytes | None = None) -> str:
     """
-    Asynchronously execute a shell command in an **unrestricted** Arch Linux terminal.
+    Asynchronously execute a shell command in an **unrestricted** terminal
+    running inside a Debian-based Python environment (`python:3.11-slim`).
     Use this tool to inspect uploaded documents under ``/data``, fetch web
     content with utilities like ``curl`` or ``wget`` and run other commands.
     The user does NOT have access to this VM, so you are

--- a/agent/vm/__init__.py
+++ b/agent/vm/__init__.py
@@ -32,9 +32,9 @@ def _sanitize(name: str) -> str:
 class LinuxVM:
     """Manage a lightweight Docker-based VM.
 
-    The default image is a CLI-based Arch Linux environment where packages
-    can be installed via ``pacman``. A custom image can be supplied via
-    ``VM_IMAGE`` and the container name is derived from
+    The default image is ``python:3.11-slim``—a minimal Debian environment
+    where packages can be installed via ``apt``. A custom image can be supplied
+    via ``VM_IMAGE`` and the container name is derived from
     ``VM_CONTAINER_TEMPLATE``.
     """
 


### PR DESCRIPTION
## Summary
- default VM image is now `python:3.11-slim`
- document the default VM image
- update tool docstrings to reference the new environment

## Testing
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_685808fd2c088321957e0805b61f6321