### PR TITLE
Add raw terminal streaming and keyboard simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,14 +138,24 @@ Stream stdout/stderr from a shell command.
 
 Arguments:
 - `command` – shell command
+- `raw` – when `true` stream the terminal output byte-by-byte
 
-The server streams raw output lines. Interactive programs may emit `{ "stdin_request": "<text>" }` when additional input is required. Clients should respond using `vm_input`.
+The server streams output lines by default. When `raw` is enabled, progress bars and other terminal effects are preserved. Interactive programs may emit `{ "stdin_request": "<text>" }` when additional input is required. Clients should respond using `vm_input` or `vm_keys`.
 
 ### `vm_input`
 Send additional input to the running VM shell.
 
 Arguments:
 - `data` – text to write to stdin
+
+Returns: `{ "result": "ok" }`.
+
+### `vm_keys`
+Simulate keystrokes in the VM shell.
+
+Arguments:
+- `data` – text to type
+- `delay` – optional delay between characters (seconds)
 
 Returns: `{ "result": "ok" }`.
 

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -12,6 +12,7 @@ from .api import (
     vm_execute,
     vm_execute_stream,
     vm_send_input,
+    vm_send_keys,
     send_notification,
 )
 from .tools import (
@@ -52,6 +53,7 @@ __all__ = [
     "vm_execute",
     "vm_execute_stream",
     "vm_send_input",
+    "vm_send_keys",
     "send_notification",
     "transcribe_audio",
     "get_memory",

--- a/agent/vm/__init__.py
+++ b/agent/vm/__init__.py
@@ -164,12 +164,13 @@ class LinuxVM:
         command: str,
         *,
         input_responder: Callable[[str], Awaitable[str | None]] | None = None,
+        raw: bool = False,
     ) -> AsyncIterator[str]:
         """Yield output from running ``command`` in the persistent shell."""
 
         shell = self._ensure_shell()
         async for part in shell.execute_stream(
-            command, input_responder=input_responder
+            command, input_responder=input_responder, raw=raw
         ):
             yield part
 
@@ -178,6 +179,12 @@ class LinuxVM:
 
         shell = self._ensure_shell()
         await shell.send_input(data)
+
+    async def shell_send_keys(self, data: str, *, delay: float = 0.05) -> None:
+        """Simulate typing ``data`` in the persistent shell."""
+
+        shell = self._ensure_shell()
+        await shell.send_keys(data, delay=delay)
 
     def execute(
         self,

--- a/agent/vm/shell.py
+++ b/agent/vm/shell.py
@@ -16,6 +16,7 @@ class PersistentShell:
         self._container = container_name
         self._env = env
         self._proc: asyncio.subprocess.Process | None = None
+        # Raw character stream from the shell
         self._queue: asyncio.Queue[str] = asyncio.Queue()
         self._reader: asyncio.Task | None = None
         self._log = get_logger(__name__)
@@ -47,24 +48,12 @@ class PersistentShell:
 
     async def _read_loop(self) -> None:
         assert self._proc and self._proc.stdout
-        buf = ""
         while True:
             chunk = await self._proc.stdout.read(1)
             if not chunk:
-                if buf:
-                    await self._queue.put(buf)
                 break
             char = chunk.decode()
-            if char == "\b":
-                buf = buf[:-1]
-                continue
-            buf += char
-            if self._is_input_prompt(buf):
-                await self._queue.put(buf)
-                buf = ""
-            elif char in {"\n", "\r"}:
-                await self._queue.put(buf)
-                buf = ""
+            await self._queue.put(char)
 
     async def stop(self) -> None:
         if self._reader and not self._reader.done():
@@ -134,6 +123,7 @@ class PersistentShell:
         command: str,
         *,
         input_responder: Optional[Callable[[str], Awaitable[str | None]]] = None,
+        raw: bool = False,
     ) -> AsyncIterator[str]:
         """Yield command output incrementally as it is produced."""
         await self.start()
@@ -141,27 +131,42 @@ class PersistentShell:
         sentinel = f"__CMD_DONE_{uuid.uuid4().hex}__"
         self._proc.stdin.write(f"{command}\necho {sentinel}\n".encode())
         await self._proc.stdin.drain()
+        buf = ""
+        line = ""
         while True:
-            line = await self._queue.get()
-            if sentinel in line:
-                break
-            if self._is_input_prompt(line):
-                yield line
-                handler = input_responder or self._default_input_responder
-                if handler is not None:
-                    try:
-                        reply = await handler(line.strip())
-                    except Exception as exc:  # pragma: no cover - unforeseen errors
-                        self._log.error("Prompt responder failed: %s", exc)
-                        reply = None
-                    if reply is not None:
-                        await self.send_input(
-                            reply if reply.endswith("\n") else f"{reply}\n"
-                        )
-                        continue
-                yield json.dumps({"stdin_request": line.strip()})
-            else:
-                yield line
+            ch = await self._queue.get()
+            if raw:
+                yield ch
+            if ch == "\b":
+                line = line[:-1]
+                buf = buf[:-1]
+                continue
+            line += ch
+            buf += ch
+            if ch in {"\n", "\r"}:
+                stripped = line.strip()
+                if stripped == sentinel:
+                    break
+                if self._is_input_prompt(line):
+                    if not raw:
+                        yield line
+                    handler = input_responder or self._default_input_responder
+                    if handler is not None:
+                        try:
+                            reply = await handler(line.strip())
+                        except Exception as exc:  # pragma: no cover - unforeseen errors
+                            self._log.error("Prompt responder failed: %s", exc)
+                            reply = None
+                        if reply is not None:
+                            send = self.send_keys if raw else self.send_input
+                            await send(reply if reply.endswith("\n") else f"{reply}\n")
+                            line = ""
+                            continue
+                    yield json.dumps({"stdin_request": line.strip()})
+                else:
+                    if not raw:
+                        yield line
+                line = ""
 
     async def send_input(self, data: str | bytes) -> None:
         """Forward ``data`` to the running shell's standard input."""
@@ -172,3 +177,13 @@ class PersistentShell:
             data = data.encode()
         self._proc.stdin.write(data)
         await self._proc.stdin.drain()
+
+    async def send_keys(self, data: str, *, delay: float = 0.05) -> None:
+        """Simulate typing ``data`` into the shell."""
+
+        await self.start()
+        assert self._proc and self._proc.stdin
+        for ch in data:
+            self._proc.stdin.write(ch.encode())
+            await self._proc.stdin.drain()
+            await asyncio.sleep(delay)


### PR DESCRIPTION
## Summary
- stream shell output byte-by-byte when `raw` flag is enabled
- add `vm_keys` API and WebSocket command for keystroke simulation
- expose keyboard helpers in the Python and WebSocket clients
- document new functionality in the README

## Testing
- `python -m pip install -r requirements.txt` *(fails: Operation cancelled)*
- `python -m compileall -q agent bot`

------
https://chatgpt.com/codex/tasks/task_e_68580fa55314832196608d9b6955b6f4