### PR TITLE
Enhance raw streaming defaults and fix lint issues

### DIFF
--- a/agent/chat/messages.py
+++ b/agent/chat/messages.py
@@ -5,8 +5,8 @@ from typing import List
 
 from ollama import Message
 
-from .schema import Msg
 from ..db import Conversation, db
+from ..utils.debug import debug_all
 
 __all__ = [
     "serialize_tool_calls",
@@ -26,7 +26,6 @@ def format_output(message: Message) -> str:
     """Return message content if present."""
 
     return message.content or ""
-
 
 
 def store_assistant_message(conversation: Conversation, message: Message) -> None:
@@ -56,6 +55,4 @@ def store_tool_message(conversation: Conversation, name: str, content: str) -> N
     db.create_message(conversation, "tool", json.dumps(data))
 
 
-from ..utils.debug import debug_all
 debug_all(globals())
-

--- a/agent/chat/state.py
+++ b/agent/chat/state.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, field
 
+from ..utils.debug import debug_all
+
 
 @dataclass
 class SessionState:
@@ -26,6 +28,4 @@ def get_state(conv_id: int) -> SessionState:
     return state
 
 
-from ..utils.debug import debug_all
 debug_all(globals())
-

--- a/agent/db/__init__.py
+++ b/agent/db/__init__.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 
+from ..utils.debug import debug_all
+
 from ..config import DB_PATH, DEFAULT_MEMORY_TEMPLATE
 
 from peewee import (
@@ -111,7 +113,9 @@ class DatabaseManager:
         conv, _ = Conversation.get_or_create(user=user, session_name=session_name)
         return conv
 
-    def create_message(self, conversation: Conversation, role: str, content: str) -> Message:
+    def create_message(
+        self, conversation: Conversation, role: str, content: str
+    ) -> Message:
         self.init_db()
         return Message.create(conversation=conversation, role=role, content=content)
 
@@ -123,10 +127,14 @@ class DatabaseManager:
             .order_by(Message.created_at)
         )
 
-    def add_document(self, username: str, file_path: str, original_name: str) -> Document:
+    def add_document(
+        self, username: str, file_path: str, original_name: str
+    ) -> Document:
         self.init_db()
         user = self.get_or_create_user(username)
-        return Document.create(user=user, file_path=file_path, original_name=original_name)
+        return Document.create(
+            user=user, file_path=file_path, original_name=original_name
+        )
 
     def list_documents(self, username: str) -> list[dict[str, str]]:
         """Return uploaded document info for ``username``."""
@@ -139,7 +147,9 @@ class DatabaseManager:
 
         docs = []
         for doc in Document.select().where(Document.user == user):
-            docs.append({"file_path": doc.file_path, "original_name": doc.original_name})
+            docs.append(
+                {"file_path": doc.file_path, "original_name": doc.original_name}
+            )
         return docs
 
     def delete_history(self, username: str, session_name: str) -> int:
@@ -166,7 +176,9 @@ class DatabaseManager:
             user.delete_instance()
         return deleted
 
-    def reset_memory(self, username: str, template: str = DEFAULT_MEMORY_TEMPLATE) -> str:
+    def reset_memory(
+        self, username: str, template: str = DEFAULT_MEMORY_TEMPLATE
+    ) -> str:
         """Reset ``username``'s memory to ``template`` and return the new value."""
 
         self.init_db()
@@ -181,7 +193,10 @@ class DatabaseManager:
             user = User.get(User.username == username)
         except User.DoesNotExist:
             return []
-        return [c.session_name for c in Conversation.select().where(Conversation.user == user)]
+        return [
+            c.session_name
+            for c in Conversation.select().where(Conversation.user == user)
+        ]
 
     def list_sessions_info(self, username: str) -> list[dict[str, str]]:
         self.init_db()
@@ -216,7 +231,6 @@ class DatabaseManager:
 
 
 db = DatabaseManager(_db)
-
 
 
 __all__ = [
@@ -311,6 +325,5 @@ def list_sessions_info(username: str) -> list[dict[str, str]]:
 
     return db.list_sessions_info(username)
 
-from ..utils.debug import debug_all
-debug_all(globals())
 
+debug_all(globals())

--- a/agent/utils/helpers.py
+++ b/agent/utils/helpers.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-__all__ = ["limit_chars"]
+import asyncio
+from typing import AsyncIterator
+
+from .debug import debug_all
+
+__all__ = ["limit_chars", "coalesce_stream"]
 
 
 def limit_chars(text: str, limit: int = 10_000) -> str:
@@ -12,6 +17,28 @@ def limit_chars(text: str, limit: int = 10_000) -> str:
     return f"(output truncated, {truncated} characters hidden)\n{text[-limit:]}"
 
 
-from .debug import debug_all
-debug_all(globals())
+async def coalesce_stream(
+    stream: AsyncIterator[str],
+    *,
+    interval: float = 0.1,
+    max_size: int = 1024,
+) -> AsyncIterator[str]:
+    """Yield buffered chunks from ``stream`` to avoid message spam."""
 
+    buffer: list[str] = []
+    size = 0
+    last = asyncio.get_running_loop().time()
+    async for chunk in stream:
+        buffer.append(chunk)
+        size += len(chunk)
+        now = asyncio.get_running_loop().time()
+        if "\n" in chunk or size >= max_size or now - last >= interval:
+            yield "".join(buffer)
+            buffer.clear()
+            size = 0
+            last = now
+    if buffer:
+        yield "".join(buffer)
+
+
+debug_all(globals())

--- a/agent/utils/secrets.py
+++ b/agent/utils/secrets.py
@@ -5,6 +5,8 @@ __all__ = ["get_secret"]
 import os
 from getpass import getpass
 
+from .debug import debug_all
+
 from .logging import get_logger
 
 _LOG = get_logger(__name__)
@@ -41,6 +43,5 @@ def get_secret(name: str, prompt: str | None = None) -> str:
         _LOG.error("Failed to obtain secret %s: %s", name, exc)
         raise RuntimeError(f"Secret {name} not provided") from exc
 
-from .debug import debug_all
-debug_all(globals())
 
+debug_all(globals())

--- a/agent/vm/return_watcher.py
+++ b/agent/vm/return_watcher.py
@@ -39,7 +39,9 @@ class ReturnWatcher:
         if self._task is not None:
             return
         try:
-            from watchfiles import awatch  # type: ignore
+            import importlib
+
+            importlib.import_module("watchfiles")
             self._watch_impl = self._watch_watchfiles
             self._use_watchfiles = True
             _LOG.debug("Using watchfiles for return directory monitoring")

--- a/bot/discord_bot.py
+++ b/bot/discord_bot.py
@@ -11,7 +11,7 @@ import base64
 import json
 from io import BytesIO
 from pathlib import Path
-from typing import Iterable, Tuple, List, Set
+from typing import Iterable, Tuple, List
 import mimetypes
 
 import discord
@@ -117,6 +117,7 @@ class DiscordTeamBot(commands.Bot):
                     user=str(ctx.author.id),
                     session=str(ctx.channel.id),
                     think=False,
+                    raw=True,
                 ):
                     parts.append(chunk)
                 output = "".join(parts).strip()
@@ -449,7 +450,9 @@ class DiscordTeamBot(commands.Bot):
                 try:
                     path.unlink()
                 except Exception as exc:  # pragma: no cover - runtime errors
-                    self._log.warning("Failed to delete returned file %s: %s", path, exc)
+                    self._log.warning(
+                        "Failed to delete returned file %s: %s", path, exc
+                    )
                 return path.name, data
         return None
 
@@ -463,7 +466,6 @@ class DiscordTeamBot(commands.Bot):
         if isinstance(payload, dict) and "stdin_request" in payload:
             return str(payload["stdin_request"])
         return None
-
 
     async def _get_connection(
         self, user: str, session: str, channel: discord.abc.Messageable


### PR DESCRIPTION
## Summary
- default to raw streaming when executing commands
- coalesce raw output in `execute_terminal_stream`
- fix import order and unused imports for `ruff`
- ensure watchfile dependency check doesn't trigger linter

## Testing
- `ruff check .`
- `black agent/api.py agent/chat/messages.py agent/chat/session.py agent/chat/state.py agent/db/__init__.py agent/server/endpoints.py agent/tools/__init__.py agent/utils/helpers.py agent/utils/secrets.py agent/vm/__init__.py agent/vm/return_watcher.py --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68581672b72c8321bf80b93902ef4eca