### PR TITLE
Convert send_notification to async

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Returns: `{ "result": "restarted" }`.
 
 ## Python API
 
-The :mod:`agent` package mirrors the WebSocket functionality and exposes helpers such as `upload_document`, `vm_execute_stream` and `send_notification`. See `agent/__init__.py` for the full list.
+The :mod:`agent` package mirrors the WebSocket functionality and exposes helpers such as `upload_document`, `vm_execute_stream` and `send_notification`. All helper functions are **asynchronous** and must be awaited. See `agent/__init__.py` for the full list.
 
 ## Persistent Memory
 
@@ -225,9 +225,10 @@ agent.edit_protected_memory("demo", "api_key", "secret")
 Notifications allow the VM to trigger asynchronous messages back to the agent. They can be queued without an active chat:
 
 ```python
+import asyncio
 import agent
 
-agent.send_notification("Report ready", user="demo")
+asyncio.run(agent.send_notification("Report ready", user="demo"))
 ```
 
 ## Configuration

--- a/agent/api.py
+++ b/agent/api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import AsyncIterator, Iterable, Callable, Awaitable
+import asyncio
 from pathlib import Path
 import base64
 import json
@@ -315,7 +316,7 @@ async def download_file(
         VMRegistry.release(user, session)
 
 
-def send_notification(
+async def send_notification(
     message: str,
     *,
     user: str = "default",
@@ -327,7 +328,8 @@ def send_notification(
     cfg = config or DEFAULT_CONFIG
     vm = VMRegistry.acquire(user, session, config=cfg)
     try:
-        vm.post_notification(str(message))
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, vm.post_notification, str(message))
     finally:
         VMRegistry.release(user, session)
 

--- a/agent/server/endpoints.py
+++ b/agent/server/endpoints.py
@@ -241,7 +241,7 @@ async def _send_notification_handler(
     chat: TeamChatSession | None,
 ) -> AsyncIterator[str]:
     message = str(params["message"])
-    send_notification(message, user=user, session=session, config=config)
+    await send_notification(message, user=user, session=session, config=config)
     yield json.dumps({"result": "ok"})
 
 


### PR DESCRIPTION
## Summary
- make `send_notification` async and run notifications in an executor
- await notification dispatch in the server endpoints
- document async API usage in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859658210888321b7e8217005f8cbeb