### PR TITLE
Fix file path on Discord upload

### DIFF
--- a/agent/chat/session.py
+++ b/agent/chat/session.py
@@ -8,6 +8,7 @@ import base64
 from typing import AsyncIterator, List, Mapping
 
 from ..utils.debug import debug_all
+from ..utils.helpers import sanitize_filename
 
 from ollama import AsyncClient, ChatResponse, Message
 
@@ -198,14 +199,15 @@ class ChatSession:
 
         dest = Path(self._config.upload_dir) / self._user.username
         dest.mkdir(parents=True, exist_ok=True)
-        target = dest / filename
+        safe_name = sanitize_filename(filename)
+        target = dest / safe_name
         target.write_bytes(data)
 
         if self._vm is not None:
-            _copy_to_vm_and_verify(self._vm, target, f"/data/{filename}")
+            _copy_to_vm_and_verify(self._vm, target, f"/data/{safe_name}")
 
-        add_document(self._user.username, str(target), filename)
-        return f"/data/{filename}"
+        add_document(self._user.username, str(target), safe_name)
+        return f"/data/{safe_name}"
 
     # ------------------------------------------------------------------
     async def edit_memory(

--- a/agent/utils/helpers.py
+++ b/agent/utils/helpers.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import AsyncIterator
 
 from .debug import debug_all
 
-__all__ = ["limit_chars", "coalesce_stream"]
+__all__ = ["limit_chars", "coalesce_stream", "sanitize_filename"]
 
 
 def limit_chars(text: str, limit: int = 10_000) -> str:
@@ -39,6 +40,16 @@ async def coalesce_stream(
             last = now
     if buffer:
         yield "".join(buffer)
+
+
+def sanitize_filename(name: str) -> str:
+    """Return a safe filename without path components."""
+
+    base = Path(name).name
+    sanitized = "".join(
+        c if c.isalnum() or c in {"-", "_", "."} else "_" for c in base
+    )
+    return sanitized or "file"
 
 
 debug_all(globals())


### PR DESCRIPTION
## Summary
- sanitize filenames when uploading documents
- ensure helper functions don't include directory traversal
- adjust Discord bot to use sanitized filenames

## Testing
- `python -m compileall -q bot agent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859aa97e0fc83218eee85fadbd7f05b