### PR TITLE
Add file return handling to chat

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -20,7 +20,13 @@
 }
 
 body {
-  background: var(--background);
+  background: linear-gradient(135deg, #0f172a, #1e293b);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+.glass {
+  background: rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -3,8 +3,11 @@ import { useState } from "react";
 import { useAgentChat } from "@/lib/useAgentChat";
 
 export default function Home() {
-  const { messages, sendMessage } = useAgentChat();
+  const { messages, sendMessage, uploadFile, setSession, session } =
+    useAgentChat();
   const [input, setInput] = useState("");
+  const [sessionInput, setSessionInput] = useState(session);
+  const [file, setFile] = useState<File | null>(null);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -14,39 +17,90 @@ export default function Home() {
     setInput("");
   };
 
+  const handleSessionUpdate = () => {
+    const s = sessionInput.trim();
+    if (s) {
+      setSession(s);
+    }
+  };
+
+  const handleUpload = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (file) {
+      uploadFile(file);
+      setFile(null);
+    }
+  };
+
   return (
-    <div className="flex flex-col h-screen bg-[color:var(--color-background)]">
+    <div className="flex flex-col h-screen bg-gradient-to-br from-slate-900 to-gray-700 text-white">
+      <header className="p-4 flex gap-2 backdrop-blur-md bg-white/10 border-b border-white/30">
+        <input
+          type="text"
+          className="flex-1 rounded-md bg-white/20 backdrop-blur px-3 py-2 placeholder-white/70"
+          placeholder="Session ID"
+          value={sessionInput}
+          onChange={(e) => setSessionInput(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={handleSessionUpdate}
+          className="px-4 py-2 rounded-md bg-blue-600/80 text-white"
+        >
+          Set
+        </button>
+      </header>
       <main className="flex-1 overflow-y-auto p-4 space-y-4">
         {messages.map((m) => (
           <div
             key={m.id}
-            className={`max-w-[80%] p-3 rounded-lg whitespace-pre-wrap break-words ${
+            className={`max-w-[80%] p-3 rounded-lg whitespace-pre-wrap break-words backdrop-blur-md border ${
               m.role === "user"
-                ? "bg-blue-600 text-white ml-auto"
-                : "bg-gray-200 text-gray-900"
+                ? "bg-blue-600/60 text-white ml-auto border-blue-300/30"
+                : "bg-white/20 text-white border-white/30"
             }`}
           >
-            {m.content}
+            {m.file ? (
+              <a href={m.file.url} download={m.file.name} className="underline">
+                {m.file.name}
+              </a>
+            ) : (
+              m.content
+            )}
           </div>
         ))}
       </main>
       <form
         onSubmit={handleSubmit}
-        className="p-4 flex gap-2 border-t border-gray-300"
+        className="p-4 flex flex-col gap-2 backdrop-blur-md bg-white/10 border-t border-white/30"
       >
         <input
           type="text"
-          className="flex-1 border rounded-md px-3 py-2"
+          className="flex-1 border rounded-md px-3 py-2 bg-white/20 backdrop-blur placeholder-white/70"
           placeholder="Type a message..."
           value={input}
           onChange={(e) => setInput(e.target.value)}
         />
-        <button
-          type="submit"
-          className="bg-blue-600 text-white px-4 py-2 rounded-md"
-        >
-          Send
-        </button>
+        <div className="flex gap-2 mt-2">
+          <input
+            type="file"
+            className="flex-1 text-white"
+            onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+          />
+          <button
+            type="button"
+            onClick={handleUpload}
+            className="px-4 py-2 rounded-md bg-green-600/80"
+          >
+            Upload
+          </button>
+          <button
+            type="submit"
+            className="px-4 py-2 rounded-md bg-blue-600/80"
+          >
+            Send
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/frontend/lib/useAgentChat.ts
+++ b/frontend/lib/useAgentChat.ts
@@ -1,9 +1,16 @@
 import { useEffect, useRef, useState, useCallback } from "react";
+import { Base64 } from "js-base64";
+
+export interface ChatFile {
+  name: string;
+  url: string;
+}
 
 export interface ChatMessage {
   id: number;
   role: "user" | "assistant";
   content: string;
+  file?: ChatFile;
 }
 
 export interface UseAgentChatOptions {
@@ -13,9 +20,11 @@ export interface UseAgentChatOptions {
 }
 
 export function useAgentChat(options: UseAgentChatOptions = {}) {
-  const { user = "demo", session = "main", think = true } = options;
+  const { user = "demo", session: initSession = "main", think = true } = options;
+  const [session, setSession] = useState(initSession);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const wsRef = useRef<WebSocket | null>(null);
+  const shouldReconnect = useRef(true);
   const idRef = useRef(0);
 
   const connect = useCallback(() => {
@@ -31,11 +40,30 @@ export function useAgentChat(options: UseAgentChatOptions = {}) {
     const ws = new WebSocket(url.toString());
 
     ws.onmessage = (e) => {
-      const part = e.data as string;
+      const raw = e.data as string;
+      try {
+        const data = JSON.parse(raw);
+        if (data.returned_file && data.data) {
+          const bytes = Base64.toUint8Array(String(data.data));
+          const url = URL.createObjectURL(new Blob([bytes]));
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: idRef.current++,
+              role: "assistant",
+              content: data.returned_file,
+              file: { name: data.returned_file, url },
+            },
+          ]);
+          return;
+        }
+      } catch {
+        /* not JSON */
+      }
+      const part = raw;
       setMessages((prev) => {
         const last = prev[prev.length - 1];
-        if (last && last.role === "assistant") {
-          // append streamed tokens
+        if (last && last.role === "assistant" && !last.file) {
           const updated = { ...last, content: last.content + part };
           return [...prev.slice(0, -1), updated];
         }
@@ -46,12 +74,22 @@ export function useAgentChat(options: UseAgentChatOptions = {}) {
       });
     };
 
+    ws.onclose = () => {
+      if (shouldReconnect.current) {
+        setTimeout(connect, 1000);
+      }
+    };
+
     wsRef.current = ws;
   }, [user, session, think]);
 
   useEffect(() => {
+    shouldReconnect.current = true;
     connect();
-    return () => wsRef.current?.close();
+    return () => {
+      shouldReconnect.current = false;
+      wsRef.current?.close();
+    };
   }, [connect]);
 
   const sendMessage = useCallback(
@@ -71,5 +109,27 @@ export function useAgentChat(options: UseAgentChatOptions = {}) {
     [connect]
   );
 
-  return { messages, sendMessage };
+  const uploadFile = useCallback(
+    async (file: File) => {
+      const buffer = await file.arrayBuffer();
+      const base64 = Base64.fromUint8Array(new Uint8Array(buffer));
+      if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
+        connect();
+      }
+      wsRef.current?.send(
+        JSON.stringify({
+          command: "upload_document",
+          args: { file_name: file.name, file_data: base64 },
+        })
+      );
+    },
+    [connect]
+  );
+
+  const changeSession = useCallback((s: string) => {
+    setSession(s);
+    setMessages([]);
+  }, []);
+
+  return { messages, sendMessage, uploadFile, setSession: changeSession, session };
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "js-base64": "^3.7.7",
         "next": "15.3.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -1121,6 +1122,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/lightningcss": {
       "version": "1.30.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,16 +9,17 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "js-base64": "^3.7.7",
+    "next": "15.3.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.3.4"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- add js-base64 dependency for easier binary handling
- show returned files from server with download links
- clean up upload logic using the library

## Testing
- `npm run build`
- `npm run lint` *(fails: requires interactive input)*

------
https://chatgpt.com/codex/tasks/task_e_685ac313442c832195574c89f7496674