### PR TITLE
Improve session management and binary upload handling

### DIFF
--- a/agent/server/endpoints.py
+++ b/agent/server/endpoints.py
@@ -85,9 +85,18 @@ async def _upload_document_handler(
     if file_data is not None:
         if not file_name:
             raise ValueError("file_name required when file_data provided")
-        data = base64.b64decode(file_data)
+        if isinstance(file_data, str):
+            data = base64.b64decode(file_data.encode())
+        elif isinstance(file_data, (bytes, bytearray)):
+            data = bytes(file_data)
+        else:
+            raise TypeError("file_data must be bytes or base64 string")
         result = await upload_data(
-            data, file_name, user=user, session=session, config=config
+            data,
+            file_name,
+            user=user,
+            session=session,
+            config=config,
         )
     else:
         file_path = str(params["file_path"])

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,12 +1,16 @@
 "use client";
 import { useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { useAgentChat } from "@/lib/useAgentChat";
 
 export default function Home() {
-  const { messages, sendMessage, uploadFile, setSession, session } =
-    useAgentChat();
+  const searchParams = useSearchParams();
+  const initialSession = searchParams.get("session") || "main";
+  const { messages, sendMessage, uploadFile } = useAgentChat({
+    session: initialSession,
+  });
   const [input, setInput] = useState("");
-  const [sessionInput, setSessionInput] = useState(session);
+  const [sessionInput, setSessionInput] = useState(initialSession);
   const [file, setFile] = useState<File | null>(null);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -19,9 +23,10 @@ export default function Home() {
 
   const handleSessionUpdate = () => {
     const s = sessionInput.trim();
-    if (s) {
-      setSession(s);
-    }
+    if (!s) return;
+    const url = new URL(window.location.href);
+    url.searchParams.set("session", s);
+    window.location.href = url.toString();
   };
 
   const handleUpload = (e: React.FormEvent) => {

--- a/frontend/lib/useAgentChat.ts
+++ b/frontend/lib/useAgentChat.ts
@@ -64,7 +64,11 @@ export function useAgentChat(options: UseAgentChatOptions = {}) {
       setMessages((prev) => {
         const last = prev[prev.length - 1];
         if (last && last.role === "assistant" && !last.file) {
-          const updated = { ...last, content: last.content + part };
+          const prefix = last.content ? "\n\n" : "";
+          const updated = {
+            ...last,
+            content: last.content + prefix + part,
+          };
           return [...prev.slice(0, -1), updated];
         }
         return [


### PR DESCRIPTION
## Summary
- refresh the page with new session IDs via query params
- format streamed chunks with extra spacing
- decode uploaded files robustly for binary data

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685acd772df88321b5dbac59970547f6