### PR TITLE
Fix bytes handling in uploads

### DIFF
--- a/agent/api.py
+++ b/agent/api.py
@@ -120,7 +120,7 @@ async def upload_document(
 
 
 async def upload_data(
-    data: bytes,
+    data: bytes | str,
     filename: str,
     *,
     user: str = "default",
@@ -134,6 +134,8 @@ async def upload_data(
     dest = Path(cfg.upload_dir) / user
     dest.mkdir(parents=True, exist_ok=True)
     target = dest / safe_name
+    if isinstance(data, str):
+        data = data.encode()
     target.write_bytes(data)
 
     vm = VMRegistry.acquire(user, session, config=cfg)

--- a/agent/chat/session.py
+++ b/agent/chat/session.py
@@ -194,13 +194,15 @@ class ChatSession:
         add_document(self._user.username, str(target), src.name)
         return f"/data/{src.name}"
 
-    def upload_data(self, data: bytes, filename: str) -> str:
+    def upload_data(self, data: bytes | str, filename: str) -> str:
         """Save ``data`` as ``filename`` for access inside the VM."""
 
         dest = Path(self._config.upload_dir) / self._user.username
         dest.mkdir(parents=True, exist_ok=True)
         safe_name = sanitize_filename(filename)
         target = dest / safe_name
+        if isinstance(data, str):
+            data = data.encode()
         target.write_bytes(data)
 
         if self._vm is not None:

--- a/agent/utils/__init__.py
+++ b/agent/utils/__init__.py
@@ -1,6 +1,5 @@
 """Utility functions exposed at package level."""
 
-from .speech import transcribe_audio
 from .memory import get_memory, set_memory, edit_memory
 
 __all__ = [
@@ -9,4 +8,21 @@ __all__ = [
     "set_memory",
     "edit_memory",
 ]
+
+
+def transcribe_audio(file_path: str, model_size: str = "tiny.en") -> str:
+    """Lazy wrapper around :func:`~agent.utils.speech.transcribe_audio`.
+
+    The optional :mod:`whisper` dependency is imported on demand so that
+    environments without the library can still use most of the package
+    functionality. A clear ``ImportError`` is raised if transcription is
+    attempted when the dependency is missing.
+    """
+
+    try:
+        from .speech import transcribe_audio as _transcribe
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise ImportError("`whisper` is required for audio transcription") from exc
+
+    return _transcribe(file_path, model_size=model_size)
 


### PR DESCRIPTION
## Summary
- lazy load whisper to avoid optional dependency crash
- support string payloads in `upload_data`
- allow chat sessions to accept string data for uploads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad1b4097483219a7b7804cf221fe1