### PR TITLE
Enable audio auto-transcription on upload

### DIFF
--- a/agent/api.py
+++ b/agent/api.py
@@ -164,7 +164,9 @@ async def transcribe_and_upload(
     if not text:
         return ""
 
-    transcript_name = sanitize_filename(f"{Path(file_path).stem}_transcript.txt")
+    transcript_name = sanitize_filename(
+        f"{Path(file_path).stem}_transcription.txt"
+    )
     return await upload_data(
         text,
         transcript_name,

--- a/bot/discord_bot.py
+++ b/bot/discord_bot.py
@@ -300,7 +300,7 @@ class DiscordTeamBot(commands.Bot):
         """Download attachments and upload them to the VM.
 
         Audio files are transcribed locally and the transcript is uploaded as
-        ``<name>_transcript.txt``. A notification is sent for every uploaded
+        ``<name>_transcription.txt``. A notification is sent for every uploaded
         file so the agent can react to new documents.
 
         Parameters
@@ -358,7 +358,7 @@ class DiscordTeamBot(commands.Bot):
                     try:
                         text = await transcribe_audio(str(dest))
                         if text:
-                            t_dest = tmpdir / f"{dest.stem}_transcript.txt"
+                            t_dest = tmpdir / f"{dest.stem}_transcription.txt"
                             t_dest.write_text(text)
                             encoded_t = base64.b64encode(t_dest.read_bytes()).decode()
                             resp = await self._client.request(

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,3 +34,9 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Audio Uploads
+
+When you upload an audio file through the interface, the backend automatically
+generates a transcript and stores it inside the Docker VM alongside the
+original file. The transcript is saved using the ``_transcription.txt`` suffix.

--- a/frontend/lib/useAgentChat.ts
+++ b/frontend/lib/useAgentChat.ts
@@ -57,6 +57,17 @@ export function useAgentChat(options: UseAgentChatOptions = {}) {
           ]);
           return;
         }
+        if (typeof data.result === "string") {
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: idRef.current++,
+              role: "assistant",
+              content: data.result,
+            },
+          ]);
+          return;
+        }
       } catch {
         /* not JSON */
       }
@@ -127,6 +138,8 @@ export function useAgentChat(options: UseAgentChatOptions = {}) {
         connect();
       }
       const data = await blob.arrayBuffer();
+      // Audio files are transcribed server-side and the resulting
+      // ``<name>_transcription.txt`` file is saved in the VM.
       wsRef.current?.send(data);
     },
     [connect]


### PR DESCRIPTION
## Summary
- save audio transcripts as `<name>_transcription.txt`
- adjust Discord bot to match new filename pattern
- improve frontend chat hook to parse result messages
- document automatic transcript creation for audio uploads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b8292a61c8321a3af9966d8b31ddb