### PR TITLE
Add Ollama to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,21 @@
 
 FROM python:3.11-slim AS runtime
 
+ARG OLLAMA_MODEL=qwen2.5
+ENV OLLAMA_MODEL=${OLLAMA_MODEL}
+
+ENV OLLAMA_KV_CACHE_TYPE=q8_0
+
 # Install OS-level dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     ffmpeg \
+    curl \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Ollama
+RUN curl -fsSL https://ollama.ai/install.sh | bash
+RUN ollama pull ${OLLAMA_MODEL}
 
 WORKDIR /app
 
@@ -19,6 +29,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application code
 COPY . .
 
-EXPOSE 8765
-
-CMD ["python", "-m", "agent"]
+EXPOSE 8765 11434
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ Messages can be raw strings or JSON payloads containing a `command` name with op
 
 ### Docker Image
 
-The Dockerfile starts the WebSocket service.
-Build and run the container exposing port `8765`:
+The Dockerfile starts the WebSocket service and an embedded Ollama instance.
+Build and run the container exposing ports `8765` and `11434`:
 
 ```bash
 docker build -t os-agent .
-docker run -p 8765:8765 os-agent
+docker run -p 8765:8765 -p 11434:11434 os-agent
 ```
 
 Environment variables allow customising the defaults:
@@ -265,6 +265,7 @@ Environment variables control most behaviour:
 | `OLLAMA_MODEL` | Ollama model name (default `qwen2.5`) |
 | `OLLAMA_HOST` | Ollama server URL |
 | `OLLAMA_NUM_CTX` | Context window size |
+| `OLLAMA_KV_CACHE_TYPE` | Ollama KV cache type (`q8_0` by default) |
 | `UPLOAD_DIR` | Host directory for uploaded files |
 | `RETURN_DIR` | Host directory for returned files |
 | `DB_PATH` | SQLite database path |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL="${OLLAMA_MODEL:-qwen2.5}"
+CACHE="${OLLAMA_KV_CACHE_TYPE:-q8_0}"
+
+log() {
+    echo "$(date +'%Y-%m-%dT%H:%M:%S') [entrypoint] $*" >&2
+}
+
+log "Pulling Ollama model: ${MODEL}"
+ollama pull "${MODEL}"
+
+log "Starting Ollama service"
+export OLLAMA_KV_CACHE_TYPE="${CACHE}"
+ollama serve &
+OLLAMA_PID=$!
+
+wait_for_ollama() {
+    for _ in {1..30}; do
+        if curl -sf http://localhost:11434/api/tags >/dev/null; then
+            return 0
+        fi
+        sleep 1
+    done
+    log "Ollama service failed to start" >&2
+    exit 1
+}
+
+wait_for_ollama
+
+cleanup() {
+    log "Shutting down..."
+    kill "${OLLAMA_PID}"
+}
+trap cleanup EXIT SIGINT SIGTERM
+
+log "Starting OS-Agent server"
+python -m agent
+


### PR DESCRIPTION
## Summary
- install Ollama during build and pull a default model
- expose ports for Ollama and WS server
- add entrypoint that starts Ollama then launches the API
- document new Docker usage and config variables

## Testing
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_685d74fe27188321b65b5162ba9ba62b