### PR TITLE
Fix entrypoint to start Ollama server

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Messages can be raw strings or JSON payloads containing a `command` name with op
 ### Docker Image
 
 The Dockerfile starts the WebSocket service and an embedded Ollama instance.
+The entrypoint automatically launches `ollama serve` with `OLLAMA_KV_CACHE_TYPE=q8_0` before downloading the requested model.
 Build and run the container exposing ports `8765` and `11434`:
 
 ```bash

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,9 +8,6 @@ log() {
     echo "$(date +'%Y-%m-%dT%H:%M:%S') [entrypoint] $*" >&2
 }
 
-log "Pulling Ollama model: ${MODEL}"
-ollama pull "${MODEL}"
-
 log "Starting Ollama service"
 export OLLAMA_KV_CACHE_TYPE="${CACHE}"
 ollama serve &
@@ -28,6 +25,9 @@ wait_for_ollama() {
 }
 
 wait_for_ollama
+
+log "Pulling Ollama model: ${MODEL}"
+ollama pull "${MODEL}"
 
 cleanup() {
     log "Shutting down..."


### PR DESCRIPTION
## Summary
- start the Ollama server before pulling the model
- mention automatic Ollama start in the README

## Testing
- `python -m compileall docker-entrypoint.sh README.md`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685d7c6d06108321bfcd77b7c80c0ed3