### PR TITLE
Add web frontend and static file server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application code
 COPY . .
 
-EXPOSE 8765 11434
+EXPOSE 8765 8080 11434
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -75,12 +75,16 @@ Messages can be raw strings or JSON payloads containing a `command` name with op
 
 The Dockerfile starts the WebSocket service and an embedded Ollama instance.
 The entrypoint automatically launches `ollama serve` with `OLLAMA_KV_CACHE_TYPE=q8_0` before downloading the requested model.
-Build and run the container exposing ports `8765` and `11434`:
+Build and run the container exposing ports `8765`, `8080` and `11434`:
 
 ```bash
 docker build -t os-agent .
-docker run -p 8765:8765 -p 11434:11434 os-agent
+docker run -p 8765:8765 -p 8080:8080 -p 11434:11434 os-agent
 ```
+
+The container also serves a static web UI on port `8080`. Open
+`http://localhost:8080` after the container starts to interact with the agent
+from your browser.
 
 The Ollama model specified by `OLLAMA_MODEL` is downloaded when the container
 starts. Building the image does not require the model to be present.

--- a/agent/static_server.py
+++ b/agent/static_server.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import argparse
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+__all__ = ["run_server", "main"]
+
+
+def run_server(host: str, port: int, static_dir: str, returns_dir: str) -> None:
+    static_path = Path(static_dir).resolve()
+    returns_path = Path(returns_dir).resolve()
+
+    class Handler(SimpleHTTPRequestHandler):
+        def translate_path(self, path: str) -> str:  # type: ignore[override]
+            if path.startswith('/files/'):
+                rel = path[len('/files/') :]
+                return str((returns_path / rel).resolve())
+            return str((static_path / path.lstrip('/')).resolve())
+
+    httpd = ThreadingHTTPServer((host, port), Handler)
+    print(f"HTTP server listening on {host}:{port}")
+    httpd.serve_forever()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simple static file server")
+    parser.add_argument('--host', default='0.0.0.0')
+    parser.add_argument('--port', type=int, default=8080)
+    parser.add_argument('--static-dir', default=str(Path(__file__).resolve().parent.parent / 'frontend'))
+    parser.add_argument('--returns-dir', default=str(Path.cwd() / 'returns'))
+    args = parser.parse_args()
+    run_server(args.host, args.port, args.static_dir, args.returns_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,8 +32,15 @@ ollama pull "${MODEL}"
 cleanup() {
     log "Shutting down..."
     kill "${OLLAMA_PID}"
+    if [[ -n "${HTTP_PID:-}" ]]; then
+        kill "${HTTP_PID}" || true
+    fi
 }
 trap cleanup EXIT SIGINT SIGTERM
+
+log "Starting static file server"
+python -m agent.static_server --port "${FRONTEND_PORT:-8080}" &
+HTTP_PID=$!
 
 log "Starting OS-Agent server"
 python -m agent

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -1,0 +1,83 @@
+export class AgentClient {
+  constructor({ host = location.hostname, port = 8765, user = 'demo', session = 'main', think = true } = {}) {
+    this.host = host;
+    this.port = port;
+    this.user = user;
+    this.session = session;
+    this.think = think;
+    this.ws = null;
+  }
+
+  _buildUri() {
+    const t = this.think ? 'true' : 'false';
+    return `ws://${this.host}:${this.port}/?user=${encodeURIComponent(this.user)}&session=${encodeURIComponent(this.session)}&think=${t}`;
+  }
+
+  connect() {
+    if (this.ws) {
+      this.ws.close();
+    }
+    const uri = this._buildUri();
+    this.ws = new WebSocket(uri);
+    return new Promise((resolve, reject) => {
+      this.ws.onopen = () => resolve();
+      this.ws.onerror = (e) => reject(e);
+    });
+  }
+
+  onMessage(cb) {
+    if (!this.ws) return;
+    this.ws.addEventListener('message', (ev) => cb(ev.data));
+  }
+
+  sendCommand(command, args = {}) {
+    if (!this.ws) throw new Error('Not connected');
+    this.ws.send(JSON.stringify({ command, args }));
+  }
+
+  sendPrompt(text) {
+    this.sendCommand('team_chat', { prompt: text });
+  }
+
+  async uploadFile(file) {
+    if (!this.ws) throw new Error('Not connected');
+    const header = { command: 'upload_document', args: { file_name: file.name } };
+    const headerBytes = new TextEncoder().encode(JSON.stringify(header));
+    const lenBuf = new Uint32Array([headerBytes.length]);
+    const fileBuf = new Uint8Array(await file.arrayBuffer());
+    const payload = new Uint8Array(4 + headerBytes.length + fileBuf.length);
+    payload.set(new Uint8Array(lenBuf.buffer), 0);
+    payload.set(headerBytes, 4);
+    payload.set(fileBuf, 4 + headerBytes.length);
+    this.ws.send(payload);
+  }
+
+  async uploadAudio(blob, name = 'audio.webm') {
+    const file = new File([blob], name, { type: blob.type || 'audio/webm' });
+    await this.uploadFile(file);
+  }
+
+  async request(command, args = {}) {
+    const uri = this._buildUri();
+    const ws = new WebSocket(uri);
+    return new Promise((resolve, reject) => {
+      ws.onopen = () => {
+        ws.send(JSON.stringify({ command, args }));
+      };
+      ws.onmessage = (ev) => {
+        try {
+          const data = JSON.parse(ev.data);
+          if ('result' in data || 'error' in data) {
+            ws.close();
+            resolve(data);
+          }
+        } catch {
+          /* ignore streaming data */
+        }
+      };
+      ws.onerror = (e) => {
+        reject(e);
+      };
+    });
+  }
+}

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,177 @@
+import { AgentClient } from './api.js';
+
+const state = {
+  client: null,
+  messages: [],
+  recording: false,
+  mediaRecorder: null,
+  chunks: [],
+};
+
+function el(tag, attrs = {}, ...children) {
+  const e = document.createElement(tag);
+  Object.entries(attrs).forEach(([k, v]) => {
+    if (k === 'class') e.className = v;
+    else if (k === 'dataset') Object.entries(v).forEach(([dk, dv]) => e.dataset[dk] = dv);
+    else if (k in e) e[k] = v;
+    else e.setAttribute(k, v);
+  });
+  children.forEach(c => e.appendChild(typeof c === 'string' ? document.createTextNode(c) : c));
+  return e;
+}
+
+function render() {
+  const main = document.querySelector('main');
+  main.innerHTML = '';
+  state.messages.forEach(m => {
+    const msgEl = el('div', { class: `message ${m.role}` });
+    if (m.file) {
+      const link = el('a', { href: m.file.url, download: m.file.name, target: '_blank' }, m.file.name);
+      msgEl.appendChild(link);
+    } else {
+      msgEl.textContent = m.content;
+    }
+    main.appendChild(msgEl);
+  });
+  main.scrollTop = main.scrollHeight;
+}
+
+function addMessage(role, content) {
+  state.messages.push({ role, content });
+  render();
+}
+
+function addFileMessage(name, url) {
+  state.messages.push({ role: 'assistant', file: { name, url } });
+  render();
+}
+
+function setupUI() {
+  const app = document.getElementById('app');
+  const userInput = el('input', { id: 'user', value: 'demo', placeholder: 'Username' });
+  const sessionInput = el('input', { id: 'session', value: 'main', placeholder: 'Session' });
+  const thinkCheck = el('input', { id: 'think', type: 'checkbox', checked: true });
+  const connectBtn = el('button', { id: 'connect' }, 'Connect');
+  const sessionSelect = el('select', { id: 'sessions' });
+  const header = el('header', {},
+    userInput,
+    sessionInput,
+    el('label', {}, thinkCheck, ' Think'),
+    connectBtn,
+    sessionSelect
+  );
+
+  const main = el('main');
+
+  const textInput = el('textarea', { id: 'text', placeholder: 'Type a message...' });
+  const fileInput = el('input', { type: 'file', id: 'file' });
+  const fileBtn = el('button', { id: 'sendFile' }, 'Upload');
+  const recordBtn = el('button', { id: 'record' }, 'Record');
+  const sendBtn = el('button', { id: 'send' }, 'Send');
+  const controls = el('div', { class: 'controls' }, fileInput, fileBtn, recordBtn, sendBtn);
+
+  const form = el('form', {}, textInput, controls);
+
+  app.append(header, main, form);
+
+  connectBtn.addEventListener('click', async () => {
+    state.client = new AgentClient({
+      user: userInput.value.trim() || 'demo',
+      session: sessionInput.value.trim() || 'main',
+      think: thinkCheck.checked,
+    });
+    await state.client.connect();
+    state.client.onMessage(handleMessage);
+    state.messages = [];
+    render();
+    loadSessions();
+  });
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const text = textInput.value.trim();
+    if (!text) return;
+    addMessage('user', text);
+    state.client.sendPrompt(text);
+    textInput.value = '';
+  });
+
+  fileBtn.addEventListener('click', async () => {
+    const file = fileInput.files[0];
+    if (!file) return;
+    addMessage('user', `[file] ${file.name}`);
+    await state.client.uploadFile(file);
+    fileInput.value = '';
+  });
+
+  recordBtn.addEventListener('click', () => {
+    if (state.recording) {
+      state.mediaRecorder.stop();
+      recordBtn.textContent = 'Record';
+      state.recording = false;
+    } else {
+      navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
+        state.mediaRecorder = new MediaRecorder(stream);
+        state.chunks = [];
+        state.mediaRecorder.ondataavailable = e => state.chunks.push(e.data);
+        state.mediaRecorder.onstop = async () => {
+          const blob = new Blob(state.chunks, { type: 'audio/webm' });
+          addMessage('user', '[audio]');
+          await state.client.uploadAudio(blob);
+        };
+        state.mediaRecorder.start();
+        recordBtn.textContent = 'Stop';
+        state.recording = true;
+      });
+    }
+  });
+
+  sendBtn.addEventListener('click', () => {
+    form.dispatchEvent(new Event('submit'));
+  });
+}
+
+function handleMessage(raw) {
+  try {
+    const data = JSON.parse(raw);
+    if (data.error) {
+      addMessage('assistant', 'Error: ' + data.error);
+    } else if (data.result) {
+      const text = String(data.result);
+      if (text.startsWith('returns/')) {
+        const name = text.split('/').pop();
+        addFileMessage(name, `files/${name}`);
+      } else {
+        addMessage('assistant', text);
+      }
+    }
+  } catch {
+    const last = state.messages[state.messages.length - 1];
+    if (last && last.role === 'assistant' && !last.file) {
+      last.content += raw;
+    } else {
+      state.messages.push({ role: 'assistant', content: raw });
+    }
+    render();
+  }
+}
+
+async function loadSessions() {
+  if (!state.client) return;
+  const resp = await state.client.request('list_sessions');
+  const select = document.getElementById('sessions');
+  select.innerHTML = '';
+  resp.result.forEach(s => {
+    const opt = document.createElement('option');
+    opt.value = s;
+    opt.textContent = s;
+    select.appendChild(opt);
+  });
+  select.value = state.client.session;
+  select.onchange = () => {
+    document.getElementById('session').value = select.value;
+    document.getElementById('connect').click();
+  };
+}
+
+setupUI();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>OS-Agent Chat</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div id="app"></div>
+<script type="module" src="app.js"></script>
+</body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,114 @@
+:root {
+  --bg: #0f172a;
+  --bg-light: #1e293b;
+  --fg: #f8fafc;
+  --accent: #3b82f6;
+  --user-msg: #2563eb;
+  --assistant-msg: #334155;
+  --border: #475569;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background: var(--bg-light);
+  border-bottom: 1px solid var(--border);
+  align-items: center;
+}
+
+header input,
+header select {
+  padding: 0.3rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+}
+
+header button {
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  border: none;
+  background: var(--accent);
+  color: white;
+  cursor: pointer;
+}
+
+main {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.message {
+  max-width: 70%;
+  padding: 0.5rem 0.8rem;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.message.user {
+  align-self: flex-end;
+  background: var(--user-msg);
+}
+
+.message.assistant {
+  align-self: flex-start;
+  background: var(--assistant-msg);
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background: var(--bg-light);
+  border-top: 1px solid var(--border);
+}
+
+form textarea {
+  resize: vertical;
+  min-height: 3rem;
+  max-height: 10rem;
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+}
+
+.controls {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.controls button {
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  border: none;
+  background: var(--accent);
+  color: white;
+  cursor: pointer;
+}
+
+#sessions {
+  margin-left: auto;
+}
+


### PR DESCRIPTION
## Summary
- add simple HTML/JS frontend for chatting with OS‑Agent
- expose static file server from Docker entrypoint
- update Dockerfile with frontend port
- document new UI in README

## Testing
- `python -m py_compile agent/static_server.py`
- `python agent/static_server.py --host 127.0.0.1 --port 9000 &`
- `curl -I http://127.0.0.1:9000/`


------
https://chatgpt.com/codex/tasks/task_e_685d7e5d7adc8321b94c30829d734fd9