### PR TITLE
Run frontend at container start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN set -eux; \
     curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg; \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" > /etc/apt/sources.list.d/docker.list; \
     apt-get update; \
-    apt-get install -y --no-install-recommends docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin; \
+    apt-get install -y --no-install-recommends \
+        docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin \
+        nodejs npm; \
     rm -rf /var/lib/apt/lists/*
 
 # Install Ollama
@@ -39,6 +41,14 @@ COPY requirements.txt ./
 
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Build frontend
+WORKDIR /app/frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build
+WORKDIR /app
 
 # Copy application code
 COPY . .

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ docker build -t os-agent .
 docker run --privileged -p 8765:8765 -p 8080:8080 -p 11434:11434 os-agent
 ```
 
-The container also serves a static web UI on port `8080`. Open
+The container also runs the Next.js frontend on port `8080`. Open
 `http://localhost:8080` after the container starts to interact with the agent
 from your browser.
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -59,8 +59,8 @@ cleanup() {
 }
 trap cleanup EXIT SIGINT SIGTERM
 
-log "Starting static file server"
-python -m agent.static_server --port "${FRONTEND_PORT:-8080}" &
+log "Starting frontend"
+(cd /app/frontend && npm start -- -p "${FRONTEND_PORT:-8080}") &
 HTTP_PID=$!
 
 log "Starting OS-Agent server"

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { useState } from "react";
+import { useState, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { useAgentChat } from "@/lib/useAgentChat";
 
-export default function Home() {
+function ChatUI() {
   const searchParams = useSearchParams();
   const initialSession = searchParams.get("session") || "main";
   const { messages, sendMessage, uploadFile } = useAgentChat({
@@ -108,5 +108,13 @@ export default function Home() {
         </div>
       </form>
     </div>
+  );
+}
+
+export default function Home() {
+  return (
+    <Suspense>
+      <ChatUI />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- run Next.js frontend when the Docker container starts
- install Node and build the frontend during the image build
- update README with frontend info
- fix Next.js build error by wrapping `ChatUI` in `Suspense`

## Testing
- `pip install -r requirements.txt` *(fails: torch download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685d8bbdd2d08321b997365c1522cc1e