### PR TITLE
Add recording and session management UI

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,6 +2,10 @@
 import { useState, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { useAgentChat } from "@/lib/useAgentChat";
+import dynamic from "next/dynamic";
+import Link from "next/link";
+
+const Recorder = dynamic(() => import("@/components/Recorder"), { ssr: false });
 
 function ChatUI() {
   const searchParams = useSearchParams();
@@ -54,6 +58,9 @@ function ChatUI() {
         >
           Set
         </button>
+        <Link href="/sessions" className="px-4 py-2 rounded-md bg-purple-600/80 text-white">
+          Sessions
+        </Link>
       </header>
       <main className="flex-1 overflow-y-auto p-4 space-y-4">
         {messages.map((m) => (
@@ -99,6 +106,7 @@ function ChatUI() {
           >
             Upload
           </button>
+          <Recorder onSave={uploadFile} />
           <button
             type="submit"
             className="px-4 py-2 rounded-md bg-blue-600/80"

--- a/frontend/app/sessions/page.tsx
+++ b/frontend/app/sessions/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { sendAgentCommand } from "@/lib/agentApi";
+
+interface SessionInfo {
+  name: string;
+  last_message: string;
+}
+
+export default function SessionsPage() {
+  const [sessions, setSessions] = useState<SessionInfo[]>([]);
+  useEffect(() => {
+    sendAgentCommand<SessionInfo[]>("list_sessions_info")
+      .then((res) => setSessions(res))
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <div className="min-h-screen p-4 bg-gradient-to-br from-slate-900 to-gray-700 text-white">
+      <h1 className="text-2xl font-bold mb-4">Sessions</h1>
+      <ul className="space-y-2">
+        {sessions.map((s) => (
+          <li
+            key={s.name}
+            className="flex justify-between items-center p-3 rounded-md bg-white/10 border border-white/30"
+          >
+            <div>
+              <span className="font-mono">{s.name}</span>
+              {s.last_message && (
+                <span className="ml-2 text-sm text-gray-300">
+                  {s.last_message.slice(0, 60)}
+                </span>
+              )}
+            </div>
+            <Link
+              href={`/?session=${encodeURIComponent(s.name)}`}
+              className="px-3 py-1 rounded-md bg-blue-600/80"
+            >
+              Open
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-4">
+        <Link href="/" className="underline">
+          Back to Chat
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/Recorder.tsx
+++ b/frontend/components/Recorder.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { useEffect } from "react";
+import { useReactMediaRecorder } from "react-media-recorder";
+
+interface Props {
+  onSave: (file: File) => void;
+}
+
+export default function Recorder({ onSave }: Props) {
+  const {
+    status,
+    startRecording,
+    stopRecording,
+    mediaBlobUrl,
+    clearBlobUrl,
+  } = useReactMediaRecorder({ audio: true });
+
+  useEffect(() => {
+    if (!mediaBlobUrl) return;
+    (async () => {
+      const blob = await fetch(mediaBlobUrl).then((r) => r.blob());
+      const file = new File([blob], `recording-${Date.now()}.webm`, {
+        type: blob.type,
+      });
+      onSave(file);
+      clearBlobUrl();
+    })();
+  }, [mediaBlobUrl, onSave, clearBlobUrl]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={status === "recording" ? stopRecording : startRecording}
+        className="px-4 py-2 rounded-md bg-red-600/80"
+      >
+        {status === "recording" ? "Stop" : "Record"}
+      </button>
+      {status !== "idle" && (
+        <span className="self-center text-sm text-gray-300 ml-2">{status}</span>
+      )}
+    </>
+  );
+}

--- a/frontend/lib/agentApi.ts
+++ b/frontend/lib/agentApi.ts
@@ -1,0 +1,56 @@
+export interface AgentApiOptions {
+  user?: string;
+  session?: string;
+  think?: boolean;
+  timeoutMs?: number;
+}
+
+export async function sendAgentCommand<T = unknown>(
+  command: string,
+  args: Record<string, unknown> = {},
+  options: AgentApiOptions = {}
+): Promise<T> {
+  const {
+    user = "demo",
+    session = "main",
+    think = true,
+    timeoutMs = 10000,
+  } = options;
+  const url = new URL(
+    process.env.NEXT_PUBLIC_AGENT_WS_URL || "ws://localhost:8765"
+  );
+  url.searchParams.set("user", user);
+  url.searchParams.set("session", session);
+  url.searchParams.set("think", think ? "true" : "false");
+
+  return new Promise<T>((resolve, reject) => {
+    const ws = new WebSocket(url.toString());
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(new Error("timeout"));
+    }, timeoutMs);
+
+    ws.onerror = (err) => {
+      clearTimeout(timer);
+      ws.close();
+      reject(err instanceof Event ? new Error("WebSocket error") : (err as any));
+    };
+
+    ws.onmessage = (e) => {
+      try {
+        const data = JSON.parse(e.data as string);
+        if (data.result !== undefined) {
+          clearTimeout(timer);
+          ws.close();
+          resolve(data.result as T);
+        }
+      } catch {
+        // ignore non JSON
+      }
+    };
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ command, args }));
+    };
+  });
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "js-base64": "^3.7.7",
         "next": "15.3.4",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-media-recorder": "^1.7.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -47,6 +48,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -976,6 +986,31 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/automation-events": {
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.11.tgz",
+      "integrity": "sha512-TnclbJ0482ydRenzrR9FIbqalHScBBdQTIXv8tVunhYx8dq7E0Eq5v5CSAo67YmLXNbx5jCstHcLZDJ33iONDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
+    },
+    "node_modules/broker-factory": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.7.tgz",
+      "integrity": "sha512-RxbMXWq/Qvw9aLZMvuooMtVTm2/SV9JEpxpBbMuFhYAnDaZxctbJ+1b9ucHxADk/eQNqDijvWQjLVARqExAeyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "fast-unique-numbers": "^9.0.22",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.43"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -1068,12 +1103,36 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/compilerr": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/compilerr/-/compilerr-10.0.2.tgz",
+      "integrity": "sha512-CFwUXxJ9OuWsSvnLSbefxi+GLsZ0YnuJh40ry5QdmZ1FWK59OG+QB8XSj6t7Kq+/c5DSS7en+cML6GlzHKH58A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "dashify": "^2.0.0",
+        "indefinite-article": "0.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.15.4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dashify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dashify/-/dashify-2.0.0.tgz",
+      "integrity": "sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.0.4",
@@ -1099,12 +1158,81 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/extendable-media-recorder": {
+      "version": "6.6.10",
+      "resolved": "https://registry.npmjs.org/extendable-media-recorder/-/extendable-media-recorder-6.6.10.tgz",
+      "integrity": "sha512-gnSmLqDFq40ZdbGfuarnMLNqYPLCPpPr0p21V+g67wG4Pv2oCc/ga8sfsZrEM5GywEi7FcpyRm3z99JWZ/0aPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.9",
+        "media-encoder-host": "^8.0.76",
+        "multi-buffer-data-view": "^3.0.20",
+        "recorder-audio-worklet": "^5.1.26",
+        "standardized-audio-context": "^25.3.29",
+        "subscribable-things": "^2.1.6",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/extendable-media-recorder-wav-encoder": {
+      "version": "7.0.129",
+      "resolved": "https://registry.npmjs.org/extendable-media-recorder-wav-encoder/-/extendable-media-recorder-wav-encoder-7.0.129.tgz",
+      "integrity": "sha512-/wqM2hnzvLy/iUlg/EU3JIF8MJcidy8I77Z7CCm5+CVEClDfcs6bH9PgghuisndwKTaud0Dh48RTD83gkfEjCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "extendable-media-recorder-wav-encoder-broker": "^7.0.119",
+        "extendable-media-recorder-wav-encoder-worker": "^8.0.116",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/extendable-media-recorder-wav-encoder-broker": {
+      "version": "7.0.119",
+      "resolved": "https://registry.npmjs.org/extendable-media-recorder-wav-encoder-broker/-/extendable-media-recorder-wav-encoder-broker-7.0.119.tgz",
+      "integrity": "sha512-BLrFOnqFLpsmmNpSk/TfjNs4j6ImCSGtoryIpRlqNu5S/Avt6gRJI0s4UYvdK7h17PCi+8vaDr75blvmU1sYlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "broker-factory": "^3.1.7",
+        "extendable-media-recorder-wav-encoder-worker": "^8.0.116",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/extendable-media-recorder-wav-encoder-worker": {
+      "version": "8.0.116",
+      "resolved": "https://registry.npmjs.org/extendable-media-recorder-wav-encoder-worker/-/extendable-media-recorder-wav-encoder-worker-8.0.116.tgz",
+      "integrity": "sha512-bJPR0B7ZHeoqi9YoSie+UXAfEYya3efQ9eLiWuyK4KcOv+SuYQvWCoyzX5kjvb6GqIBCUnev5xulfeHRlyCwvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.43"
+      }
+    },
+    "node_modules/fast-unique-numbers": {
+      "version": "9.0.22",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.22.tgz",
+      "integrity": "sha512-dBR+30yHAqBGvOuxxQdnn2lTLHCO6r/9B+M4yF8mNrzr3u1yiF+YVJ6u3GTyPN/VRWqaE1FcscZDdBgVKmrmQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/indefinite-article": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/indefinite-article/-/indefinite-article-0.0.2.tgz",
+      "integrity": "sha512-Au/2XzRkvxq2J6w5uvSSbBKPZ5kzINx5F2wb0SF8xpRL8BP9Lav81TnRbfPp6p+SYjYxwaaLn4EUwI3/MmYKSw==",
+      "license": "MIT"
     },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
@@ -1378,6 +1506,43 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/media-encoder-host": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/media-encoder-host/-/media-encoder-host-8.1.0.tgz",
+      "integrity": "sha512-VwX3ex48ltl+K1ObGEq3IcZp/XqpNTWemd9brC9ovo89rYmCRKTZAp1FCyfAY86RdvSMrUs26lbo45DIDVyERg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.4",
+        "media-encoder-host-broker": "^7.1.0",
+        "media-encoder-host-worker": "^9.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/media-encoder-host-broker": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/media-encoder-host-broker/-/media-encoder-host-broker-7.1.0.tgz",
+      "integrity": "sha512-Emu3f45Wbf6AoRJxfvZ8e5nh8fRVviBfkABgYNvVUsVBgJ7+l137gn324g/JmNVQhhVQ89fjmGT1kHIJ9JG5Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.4",
+        "broker-factory": "^3.0.97",
+        "fast-unique-numbers": "^9.0.4",
+        "media-encoder-host-worker": "^9.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/media-encoder-host-worker": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/media-encoder-host-worker/-/media-encoder-host-worker-9.2.0.tgz",
+      "integrity": "sha512-LrJJgNBDZH2y1PYBLaiYQw9uFU5i3yPvDkDxdko+L3Z4qzhKq9+4eYxKDqlwO4EdOlaiggvMpkgZl3roOniz2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.4",
+        "extendable-media-recorder-wav-encoder-broker": "^7.0.100",
+        "tslib": "^2.6.2",
+        "worker-factory": "^7.0.24"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -1415,6 +1580,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/multi-buffer-data-view": {
+      "version": "3.0.24",
+      "resolved": "https://registry.npmjs.org/multi-buffer-data-view/-/multi-buffer-data-view-3.0.24.tgz",
+      "integrity": "sha512-jm7Ycplx37ExXyQmqhwl7zfQmAj81y5LLzVx0XyWea4omP9W/xJhLEHs/5b+WojGyYSRt8BHiXZVcYzu68Ma0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.6",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=12.20.1"
       }
     },
     "node_modules/nanoid": {
@@ -1573,6 +1751,73 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-media-recorder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/react-media-recorder/-/react-media-recorder-1.7.1.tgz",
+      "integrity": "sha512-OIYA4pfGR1HbRm4aB/mv2EswDSBanh+NbUyUEEeIaHVpmsF3AOr4T0te4CgIn5ijja85A/KI+JimVoiQ93dNgA==",
+      "license": "MIT",
+      "dependencies": {
+        "extendable-media-recorder": "^6.6.5",
+        "extendable-media-recorder-wav-encoder": "^7.0.68"
+      }
+    },
+    "node_modules/recorder-audio-worklet": {
+      "version": "5.1.39",
+      "resolved": "https://registry.npmjs.org/recorder-audio-worklet/-/recorder-audio-worklet-5.1.39.tgz",
+      "integrity": "sha512-w/RazoBwZnkFnEPRsJYNThOHznLQC98/IzWRrutpJQVvCcL0nbLsVSLDaRrnrqVpRUI11VgiXRh30HaHiSdVhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "broker-factory": "^3.0.75",
+        "fast-unique-numbers": "^7.0.2",
+        "recorder-audio-worklet-processor": "^4.2.21",
+        "standardized-audio-context": "^25.3.41",
+        "subscribable-things": "^2.1.14",
+        "tslib": "^2.5.0",
+        "worker-factory": "^6.0.76"
+      }
+    },
+    "node_modules/recorder-audio-worklet-processor": {
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/recorder-audio-worklet-processor/-/recorder-audio-worklet-processor-4.2.21.tgz",
+      "integrity": "sha512-oiiS2sp6eMxkvjt13yetSYUJvnAxBZk60mIxz0Vf/2lDWa/4svCyMLHIDzYKbHahkISd0UYyqLS9dI7xDlUOCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/recorder-audio-worklet/node_modules/fast-unique-numbers": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-7.0.2.tgz",
+      "integrity": "sha512-xnqpsnu889bHbq5cbDMwCJ2BPf6kjFPMu+RHfqKvisRxeEbTOVxY5aW/ZNsZ/r8OlwatxmjdFEVQog2xAhLkvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.15.4"
+      }
+    },
+    "node_modules/recorder-audio-worklet/node_modules/worker-factory": {
+      "version": "6.0.76",
+      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-6.0.76.tgz",
+      "integrity": "sha512-W1iBNPmE9p0asU4aFmYJYCnMxhkvk4qlKc660GlHxWgmflY64NxxTbmKqipu4K5p9LiKKPjqXfcQme6153BZEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "compilerr": "^10.0.2",
+        "fast-unique-numbers": "^7.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/rxjs-interop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rxjs-interop/-/rxjs-interop-2.0.0.tgz",
+      "integrity": "sha512-ASEq9atUw7lualXB+knvgtvwkCEvGWV2gDD/8qnASzBkzEARZck9JAyxmY8OS6Nc1pCPEgDTKNcx+YqqYfzArw==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -1653,6 +1898,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/standardized-audio-context": {
+      "version": "25.3.77",
+      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
+      "integrity": "sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6",
+        "automation-events": "^7.0.9",
+        "tslib": "^2.7.0"
+      }
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -1682,6 +1938,17 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/subscribable-things": {
+      "version": "2.1.53",
+      "resolved": "https://registry.npmjs.org/subscribable-things/-/subscribable-things-2.1.53.tgz",
+      "integrity": "sha512-zWvN9F/eYQWDKszXl4NXkyqPXvMDZDmXfcHiM5C5WQZTTY2OK+2TZeDlA9oio69FEPqPu9T6yeEcAhQ2uRmnaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "rxjs-interop": "^2.0.0",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/tailwindcss": {
@@ -1745,6 +2012,17 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/worker-factory": {
+      "version": "7.0.43",
+      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.43.tgz",
+      "integrity": "sha512-SACVoj3gWKtMVyT9N+VD11Pd/Xe58+ZFfp8b7y/PagOvj3i8lU3Uyj+Lj7WYTmSBvNLC0JFaQkx44E6DhH5+WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "fast-unique-numbers": "^9.0.22",
+        "tslib": "^2.8.1"
+      }
     },
     "node_modules/yallist": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "js-base64": "^3.7.7",
     "next": "15.3.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-media-recorder": "^1.7.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- support WS API commands via `sendAgentCommand`
- add a recorder component based on `react-media-recorder`
- add sessions list page and link from chat
- integrate audio recording in chat UI
- include `react-media-recorder` dependency

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685d8e1009988321857c8f3d666e1a26