### PR TITLE
Add GPU support for Ollama container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,12 @@ ENV OLLAMA_MODEL=${OLLAMA_MODEL}
 
 ENV OLLAMA_KV_CACHE_TYPE=q8_0
 
+# Enable GPU access when available. The NVIDIA runtime will
+# expose the host GPUs when the container is started with
+# `--gpus` or the Nvidia container runtime.
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
 # Install OS-level dependencies
 RUN set -eux; \
     apt-get update; \

--- a/README.md
+++ b/README.md
@@ -79,8 +79,12 @@ Build and run the container exposing ports `8765`, `8080` and `11434`:
 
 ```bash
 docker build -t os-agent .
-docker run --privileged -p 8765:8765 -p 8080:8080 -p 11434:11434 os-agent
+docker run --gpus all --privileged -p 8765:8765 -p 8080:8080 -p 11434:11434 os-agent
 ```
+
+The `--gpus all` flag grants the container full access to your GPU when
+available. If your system does not have a GPU or the NVIDIA runtime is not
+installed, simply omit this flag to run in CPU-only mode.
 
 The container also runs the Next.js frontend on port `8080`. Open
 `http://localhost:8080` after the container starts to interact with the agent
@@ -285,6 +289,8 @@ Environment variables control most behaviour:
 | `OLLAMA_HOST` | Ollama server URL |
 | `OLLAMA_NUM_CTX` | Context window size |
 | `OLLAMA_KV_CACHE_TYPE` | Ollama KV cache type (`q8_0` by default) |
+| `NVIDIA_VISIBLE_DEVICES` | GPUs to expose inside the container (`all` by default) |
+| `NVIDIA_DRIVER_CAPABILITIES` | NVIDIA driver capabilities (`compute,utility`) |
 | `UPLOAD_DIR` | Host directory for uploaded files |
 | `RETURN_DIR` | Host directory for returned files |
 | `DB_PATH` | SQLite database path |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,6 +26,12 @@ wait_for_docker() {
 
 wait_for_docker
 
+if command -v nvidia-smi >/dev/null 2>&1; then
+    log "NVIDIA GPU detected, enabling GPU acceleration"
+else
+    log "No NVIDIA GPU detected, running Ollama in CPU mode"
+fi
+
 log "Starting Ollama service"
 export OLLAMA_KV_CACHE_TYPE="${CACHE}"
 ollama serve &


### PR DESCRIPTION
## Summary
- enable GPU access via NVIDIA runtime in Dockerfile
- log GPU availability at container startup
- document `--gpus all` run option and NVIDIA variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d96cb45e08321a6199c395bc339fc