### PR TITLE
Fix frontend websocket URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ The container also runs the Next.js frontend on port `8080`. Open
 `http://localhost:8080` after the container starts to interact with the agent
 from your browser.
 
+The frontend tries to connect to the agent WebSocket on the same host. If the
+service runs on a different host or port, set `NEXT_PUBLIC_AGENT_WS_URL`
+accordingly when building the image.
+
 The Ollama model specified by `OLLAMA_MODEL` is downloaded when the container
 starts. Building the image does not require the model to be present.
 

--- a/frontend/lib/agentApi.ts
+++ b/frontend/lib/agentApi.ts
@@ -1,3 +1,5 @@
+import { getWsUrl } from "./wsUrl";
+
 export interface AgentApiOptions {
   user?: string;
   session?: string;
@@ -16,9 +18,7 @@ export async function sendAgentCommand<T = unknown>(
     think = true,
     timeoutMs = 10000,
   } = options;
-  const url = new URL(
-    process.env.NEXT_PUBLIC_AGENT_WS_URL || "ws://localhost:8765"
-  );
+  const url = new URL(getWsUrl());
   url.searchParams.set("user", user);
   url.searchParams.set("session", session);
   url.searchParams.set("think", think ? "true" : "false");

--- a/frontend/lib/useAgentChat.ts
+++ b/frontend/lib/useAgentChat.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { Base64 } from "js-base64";
+import { getWsUrl } from "./wsUrl";
 
 export interface ChatFile {
   name: string;
@@ -30,9 +31,7 @@ export function useAgentChat(options: UseAgentChatOptions = {}) {
   const connect = useCallback(() => {
     if (wsRef.current) wsRef.current.close();
 
-    const url = new URL(
-      process.env.NEXT_PUBLIC_AGENT_WS_URL || "ws://localhost:8765"
-    );
+    const url = new URL(getWsUrl());
     url.searchParams.set("user", user);
     url.searchParams.set("session", session);
     url.searchParams.set("think", think ? "true" : "false");

--- a/frontend/lib/wsUrl.ts
+++ b/frontend/lib/wsUrl.ts
@@ -1,0 +1,8 @@
+export function getWsUrl(): string {
+  const envUrl = process.env.NEXT_PUBLIC_AGENT_WS_URL;
+  if (envUrl) return envUrl;
+  if (typeof window === 'undefined') return 'ws://localhost:8765';
+  const { protocol, hostname } = window.location;
+  const scheme = protocol === 'https:' ? 'wss' : 'ws';
+  return `${scheme}://${hostname}:8765`;
+}


### PR DESCRIPTION
## Summary
- add helper to build the websocket URL from the browser host
- use helper in agent API and chat hook
- document websocket URL in README

## Testing
- `npm ci`
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686037e422dc8321bb5876810bf41de0